### PR TITLE
ADD RPG GAMES

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9708,4 +9708,15 @@
         <Description>Autosplitter for SWD3 1.02. (By master_fiora)</Description>
         <Website>https://www.speedrun.com/swd3/resources</Website>
     </AutoSplitter>
+        <AutoSplitter>
+        <Games>
+            <Game>The Legend of Sword and Fairy 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/WeiZhouHong/Pal2_AutoSplitters/master/pal2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter for PAL2 1.05. (By master_fiora)</Description>
+        <Website>https://www.speedrun.com/the_legend_of_sword_and_fairy_2/resources</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Because the loading time of this game is too much affected by the hardware
The timing rules will be changed. Remove loading time and auto-split.
https://www.speedrun.com/the_legend_of_sword_and_fairy_2