### PR TITLE
Use new auto splitter for Jedi Outcast

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2207,10 +2207,10 @@
             <Game>JK II: Jedi Outcast</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/JMaynard24/ASL/master/JKJO.asl</URL>
+            <URL>https://raw.githubusercontent.com/kugelrund/LiveSplit.JediOutcast/master/JKJO.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal are available. (By Dread)</Description>
+        <Description>Auto Splitting and Load Removal are available. (By Dread and Sphere)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Jedi Outcast now allows the use of a source port which offers an ingame timer. The ASL script therefore needs some major update. As Dread is not that active in the community anymore, he proposed moving the repository.