### PR TITLE
Updated autosplitter for Overture 1.0 and 1.1

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2028,6 +2028,19 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Penumbra: Overture</Game>
+            <Game>Penumbra Overture</Game>
+            <Game>Overture</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Astropilot/PenumbraOvertureAutoSplitter/main/Penumbra_Overture.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter is availaible.</Description>
+        <Website>https://github.com/Astropilot/PenumbraOvertureAutoSplitter/blob/main/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>BioShock: The Collection</Game>
             <Game>BioShock The Collection</Game>
             <Game>BioShock Remastered</Game>


### PR DESCRIPTION
- New game time
- Auto reset
- 1.0 and 1.1 compatibility

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
