### PR TITLE
Update Superliminal branch and script name

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9279,7 +9279,7 @@
             <Game>Superliminal</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/loriswit/asl/master/superliminal_v3.asl</URL>
+            <URL>https://raw.githubusercontent.com/loriswit/asl/main/superliminal.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start/split/reset and load removal available.</Description>


### PR DESCRIPTION
Removes the version number from the script name, which was confusing.
The old URL will remain available.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
