### PR TITLE
Remove website link for Hades autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10457,7 +10457,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitter and Reset (SystematicSkid)</Description>
-	<Website>https://systemfailu.re</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Websites shouldn't be included unless they are directly relevant to the Auto Splitter.

cc: @SystematicSkid 