### PR TITLE
Update Sekiro script to include version 1.06

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7533,7 +7533,7 @@
             <Game>Sekiro: Shadows Die Twice</Game>
         </Games>
         <URLs>
-            <URL>https://gist.githubusercontent.com/pawREP/98c2828e7550caeb521d65c581f43a69/raw/bc21b517cf28fa6edbb679a19ea87f9d1b527dc2/Sekiro.asl</URL>
+            <URL>https://gist.githubusercontent.com/RefinedHornet/70453f953d536229d093a7f86b4559cd/raw/82934d59ef2be7a55aa9637de86fd7a2be995212/Sekiro.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Game time, auto-start and several QOL improvments.</Description>


### PR DESCRIPTION
Includes version 1.06 compatibility, changes to auto start and timing that starts from non-new game.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [V] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [V] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter. - permission from original author in comments of https://gist.github.com/pawREP/98c2828e7550caeb521d65c581f43a69
