### PR TITLE
Autosplitter for Super Meat Boy Forever

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10803,4 +10803,15 @@
         <Description>Autosplitting available (by DerKO)</Description>
 	<Website>https://github.com/DerKO9/AutoSplitters/blob/master/Lorera/Lorera.asl</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Super Meat Boy Forever</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ldmnt/smbf-autosplitter/master/smbf.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Starting, resetting and in-game time available. Customize splits in the settings. (by Lev and Hamb)</Description>
+        <Website>https://discord.gg/SFq6UcMZ3y</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Identical to https://github.com/LiveSplit/LiveSplit/pull/2071 that was opened in the wrong repo.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [check] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
  NOTE : has a functionality to log segment times to a file. (The purpose is to gather data to analyze the game RNG, for random seed routing). This is deactivated by default and requires the user to turn it on through the settings, so nothing that should be a nuisance.

- [check] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
