### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
-	<AutosSplitter>
+	<AutoSplitter>
 		<Games>
 			<Game>Monkey Island™ 2 Special Edition: LeChuck’s Revenge™</Game>
    		</Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+	<AutosSplitter>
+		<Games>
+			<Game>Monkey Island™ 2 Special Edition: LeChuck’s Revenge™</Game>
+   		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/ffyte/LA-adventure-remake-autosplitters/main/lar-splitters.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>Enables In Game Time for Monkey Island 2 Special Edition and other Lucasarts remakes</Description>
+		<Website>https://discord.gg/s3Z6g8J69Q</Website>
+   </AutoSplitter>
    <AutoSplitter>
      	<Games>
             <Game>Children of Morta</Game>


### PR DESCRIPTION
Added an in game timer script for Lucasarts remakes, currently in use for Monkey Island 2 Special Edition.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x ] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
