### PR TITLE
Added autosplitter for Dandara

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11132,13 +11132,24 @@
         <Website>https://discord.gg/secretsofgrindea</Website>
     </AutoSplitter>
     <AutoSplitter>
-    <Games>
-        <Game>Karlson 2D</Game>
-    </Games>
-    <URLs>
-        <URL>https://raw.githubusercontent.com/brododragon/Karlson-2D-Autosplitter/main/karlson2dfullrelease.asl</URL>
-    </URLs>
-    <Type>Script</Type>
-    <Description>Auto starts, splits, stops, and will not time loads if set to Game Time. (by brododragon)</Description>
-</AutoSplitter>
+        <Games>
+	        <Game>Karlson 2D</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/brododragon/Karlson-2D-Autosplitter/main/karlson2dfullrelease.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto starts, splits, stops, and will not time loads if set to Game Time. (by brododragon)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Dandara</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/marcelopio/Dandara-Autosplitter/main/dandara.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Supports Autosplit, Autostart, Autoreset, Load Removal, can split on every room or saved camp</Description>
+        <Website>https://discord.gg/8t4WrMmpXs</Website>
+    </AutoSplitter>	
 </AutoSplitters>


### PR DESCRIPTION
Added just the autosplitter for Dandara. Karlson 2D lines were changed just because it was not idented correctly

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
