### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -326,7 +326,7 @@
             <URL>https://raw.githubusercontent.com/G-e-n-e-v-e-n-s-i-S/Metal-Slug-1-AutoSplitter/master/Metal%20Slug%201%20-%20AutoSplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter for Steam and WinKawaks. (By GenevensiS)</Description>
+        <Description>AutoSplitter for Steam, FightCade, and WinKawaks. (By GenevensiS)</Description>
         <Website>https://docs.google.com/document/d/1eHHgkXpr-WuTCXJB1t4R4eEcb98C_ocJdUmo-OdUv70/edit?usp=sharing</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -337,7 +337,7 @@
             <URL>https://raw.githubusercontent.com/G-e-n-e-v-e-n-s-i-S/Metal-Slug-2-AutoSplitter/master/Metal%20Slug%202%20-%20AutoSplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter for Steam and WinKawaks. (By GenevensiS)</Description>
+        <Description>AutoSplitter for Steam, FightCade, and WinKawaks. (By GenevensiS)</Description>
         <Website>https://docs.google.com/document/d/1eHHgkXpr-WuTCXJB1t4R4eEcb98C_ocJdUmo-OdUv70/edit?usp=sharing</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -348,7 +348,7 @@
             <URL>https://raw.githubusercontent.com/G-e-n-e-v-e-n-s-i-S/Metal-Slug-3-AutoSplitter/master/Metal%20Slug%203%20-%20AutoSplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter for Steam and WinKawaks. (By GenevensiS)</Description>
+        <Description>AutoSplitter for Steam, FightCade, and WinKawaks. (By GenevensiS)</Description>
         <Website>https://docs.google.com/document/d/1eHHgkXpr-WuTCXJB1t4R4eEcb98C_ocJdUmo-OdUv70/edit?usp=sharing</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -359,7 +359,7 @@
             <URL>https://raw.githubusercontent.com/G-e-n-e-v-e-n-s-i-S/Metal-Slug-4-AutoSplitter/master/Metal%20Slug%204%20-%20AutoSplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter for WinKawaks. (By GenevensiS)</Description>
+        <Description>AutoSplitter for FightCade and WinKawaks. (By GenevensiS)</Description>
         <Website>https://docs.google.com/document/d/1eHHgkXpr-WuTCXJB1t4R4eEcb98C_ocJdUmo-OdUv70/edit?usp=sharing</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -370,7 +370,7 @@
             <URL>https://raw.githubusercontent.com/G-e-n-e-v-e-n-s-i-S/Metal-Slug-5-AutoSplitter/master/Metal%20Slug%205%20-%20AutoSplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter for WinKawaks. (By GenevensiS)</Description>
+        <Description>AutoSplitter for FightCade and WinKawaks. (By GenevensiS)</Description>
         <Website>https://docs.google.com/document/d/1eHHgkXpr-WuTCXJB1t4R4eEcb98C_ocJdUmo-OdUv70/edit?usp=sharing</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -381,7 +381,7 @@
             <URL>https://raw.githubusercontent.com/G-e-n-e-v-e-n-s-i-S/Metal-Slug-X-AutoSplitter/master/Metal%20Slug%20X%20-%20AutoSplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter for Steam and WinKawaks. (By GenevensiS)</Description>
+        <Description>AutoSplitter for Steam, FightCade, and WinKawaks. (By GenevensiS)</Description>
         <Website>https://docs.google.com/document/d/1eHHgkXpr-WuTCXJB1t4R4eEcb98C_ocJdUmo-OdUv70/edit?usp=sharing</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
Added support for FightCade to the Metal Slug 12345X autosplitters

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
