### PR TITLE
HROT Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11218,4 +11218,17 @@
         <Description>AutoSplitter for Mesen, FCEUX 2.2.3 and Nestopia (By Avasam).</Description>
     	<Website>https://www.speedrun.com/mappy_land</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Harry Potter and the Goblet of Fire (PC)</Game>
+	    <Game>Harry Potter and the Goblet of Fire</Game>
+	    <Game>Harry Potter 4</Game>
+	    <Game>HP4</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/marczeslaw11/LoadRemovers/master/HP4_AutoSplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter and Load Remover by Flo203 and Marczeslaw</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [yes] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [yes] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- Adds an autosplitter for a brand new game HROT
- ~~GitHub thinks in the pull request that I'm adding another autosplitter for Harry Potter 4 - I'm not and I don't know why it's happening.~~ I think I fixed it