### PR TITLE
Needs the full stop as its excluded.

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -59,7 +59,7 @@
    </AutoSplitter>
 	<AutoSplitter>
      	<Games>
-            <Game>Fix It Felix Jr</Game>
+            <Game>Fix It Felix Jr.</Game>
      	</Games>
      	<URLs>
             <URL>https://raw.githubusercontent.com/KunoDemetries/AutoSplitter/master/FixitFelixJr.asl</URL>


### PR DESCRIPTION
The game name has a full stop at the end.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- 

- [✓] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)

- [✓] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
