### PR TITLE
fix sonic '06 off-by-one error

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6,7 +6,7 @@
 			<Game>Sonic The Hedgehog (2006) Category Extensions</Game>
 		</Games>
 		<URLs>
-			<URL>https://gist.githubusercontent.com/Labreezy/7bd45d3f36c07a86b6d68262497efd3c/raw/36da2856b9c4cb7aa45349969b5f1f936da5b6cd/sonic06.asl</URL>
+			<URL>https://gist.githubusercontent.com/Labreezy/7bd45d3f36c07a86b6d68262497efd3c/raw/0f9c6362c9e0c44b6e574ecbd3a5dedeac97573e/sonic06.asl</URL>
 		</URLs>
 		<Type>Script</Type>
 		<Description>Emulator In-Game Timer (by Labryz)</Description>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ x] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
