### PR TITLE
added category extensions

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1901,8 +1901,7 @@
     <AutoSplitter>
         <Games>
             <Game>Bully: Scholarship Edition</Game>
-            <Game>Bully</Game>
-            <Game>Canis Canem Edit</Game>
+            <Game>Bully: Scholarship Edition - Category Extension</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/LohaTronsRS/BullyAS/master/BullyAS.asl</URL>


### PR DESCRIPTION
added CE for Bully: Scholarship Edition - and removed console variants where the AS cannot be used. 

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
