### PR TITLE
Added "Mods" subcategory to existing Prince of Persia autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9819,12 +9819,13 @@
     <AutoSplitter>
         <Games>
             <Game>Prince of Persia</Game>
+	    <Game>Prince of Persia (Mods)</Game>	
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/WinterThunderSpeedrun/Autosplitters/master/PrinceOfPersia1.4.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Website>https://raw.githubusercontent.com/WinterThunderSpeedrun/Autosplitters</Website>
+        <Website>https://github.com/WinterThunderSpeedrun/Autosplitters</Website>
         <Description>Autospliter for Prince of Persia 1.4 on DOSBox 0.74-3 (In-game timer)</Description>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ x ] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
