### PR TITLE
Removed RE6 ASL.

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9720,17 +9720,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Resident Evil 6</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/JYNxYoshii/RE6_ASL/master/RE6v3_dist_IGT.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autostart, chapter splits, sub-chapter splits, works with all characters/campaigns. Tested 1.06. Visit the Github Repo for more options and info. NEED TESTERS FOR EVERYTHING BUT LEON! (By xlYoshii)</Description>
-        <Website>https://github.com/JYNxYoshii/RE6_ASL</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Carmageddon II: Carpocalypse Now</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Removed my RE6 ASL pending a rework by TheDementedSalad.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ ] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
