### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11585,9 +11585,9 @@
 			<Game>Oddworld: Stranger's Wrath</Game>
 		</Games>
 		<URLs>
-			<URL>https://raw.githubusercontent.com/Fxyzzz/Oddworld-Stranger-s-Wrath-HD-Autosplitter/main/Oddworld_Strangers_Wrath_HD_AUTOSPLITTER_2.2.asl</URL>
+			<URL>https://raw.githubusercontent.com/Fxyzzz/Oddworld-Stranger-s-Wrath-HD-Autosplitter/main/Oddworld_Strangers_Wrath_HD_AUTOSPLITTER.asl</URL>
 		</URLs>
 		<Type>Script</Type>
-		<Description>Autosplitter and IGT for Steam and GOG versions of the game</Description>
+		<Description>Autosplitter and IGT for Steam and GOG versions of the game (by Fxyz)</Description>
 	</AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Needed to change the url of my autosplitter for Oddworld: Stranger's Wrath because i had to change it's name for it not to have the version in it

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
