### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10571,8 +10571,8 @@
             <URL>https://raw.githubusercontent.com/xSHiiDOx/BiohazardAutoSplitter/master/Biohazard%20Autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>New/Updated autosplitter (by SHiiDO). Autostart, Reset and Sections added. Use new splits or update your own splits to work (explained in readme).</Description>
-        <Website>https://www.speedrun.com/re1/resources</Website>
+        <Description>New/Updated autosplitter (by SHiiDO). Autostart, Reset and Sections added. Please check Readme.</Description>
+        <Website>https://www.speedrun.com/residentevil/resources</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Updated the URL for Resident Evil / Biohazard since old URL is not working anymore. Shortened the description to be better readable in Livesplit.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
