### PR TITLE
Updated Brave Fencer Musashi Splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5,11 +5,11 @@
 			<Game>Brave Fencer Musashi</Game>
 		</Games>
 		<URLs>
-			<URL>https://gist.githubusercontent.com/amm4108/f9cc6e8c8fba5a2457762f4fab8679c7/raw/5e2107d272ecec154dbbdb0f886152f9a9d013be/BraveFencerMusashi.asl</URL>
+			<URL>https://gist.githubusercontent.com/Aalaizah/f9cc6e8c8fba5a2457762f4fab8679c7/raw/bbf537abec80745ff529ec2a1ada76a932bd9fd4/BraveFencerMusashi.asl</URL>
 		</URLs>
 		<Type>Script</Type>
 		<Description>Brave Fencer Musashi Autosplitter (by Aalaizah)</Description>
-		<Website>https://github.com/b5414/LiveSplit_ASL</Website>
+		<Website>https://gist.githubusercontent.com/Aalaizah/f9cc6e8c8fba5a2457762f4fab8679c7/raw/bbf537abec80745ff529ec2a1ada76a932bd9fd4/Readme</Website>
 	</AutoSplitter>
 	<AutoSplitter>
 		<Games>


### PR DESCRIPTION
Updated to fix a couple of splits that were splitting too often with more thorough testing. Added a readme.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
