### PR TITLE
Add AutoSplitter for The Ninja Warriors

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11872,5 +11872,15 @@
 	  <Type>Script</Type>
 	  <Description>Autosplitting and Load Removal is available. (By Melody)</Description>
 	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
+			<Game>The Ninja Warriors</Game>
+		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/phroggster/AutoSplits/master/NinjaWarriors/NinjaWarriors.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>phroggie's The Ninja Warriors Autosplitter</Description>
+	</AutoSplitter>
 </AutoSplitters>
 


### PR DESCRIPTION
The Ninja Warriors is a beat 'em up video game developed by Natsume for the Super Nintendo Entertainment System that was released in 1994. This is my first attempt at ASL, but it seems to be rock-solid for everything that I could think up to throw at it. I'm open to suggestions, patches, and/or comments on how to do this better.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
