### PR TITLE
Adding Auto-Splitter for Pepsiman (PS1/PSX)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11882,5 +11882,16 @@
 		<Type>Script</Type>
 		<Description>phroggie's The Ninja Warriors Autosplitter</Description>
 	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
+			<Game>Pepsiman</Game>
+		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/MrMonsh/Auto-Splitters/main/Pepsiman/Pepsiman%20Auto-Splitter.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>Pepsiman Auto-Splitter & Load Remover (by MrMonsh)</Description>
+		<Website>https://github.com/MrMonsh/Auto-Splitters/blob/main/Pepsiman/readme.txt</Website>
+	</AutoSplitter>
 </AutoSplitters>
 

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11890,7 +11890,7 @@
 			<URL>https://raw.githubusercontent.com/MrMonsh/Auto-Splitters/main/Pepsiman/Pepsiman%20Auto-Splitter.asl</URL>
 		</URLs>
 		<Type>Script</Type>
-		<Description>Pepsiman Auto-Splitter & Load Remover (by MrMonsh)</Description>
+		<Description>Pepsiman Auto-Splitter &amp; Load Remover (by MrMonsh)</Description>
 		<Website>https://github.com/MrMonsh/Auto-Splitters/blob/main/Pepsiman/readme.txt</Website>
 	</AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
