### PR TITLE
Removed the Minecraft: Java Edition component

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10381,18 +10381,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Minecraft: Java Edition</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Jorkoh/LiveSplit.Minecraft/master/Components/LiveSplit.Minecraft.dll</URL>
-            <URL>https://raw.githubusercontent.com/Jorkoh/LiveSplit.Minecraft/master/Components/fNbt.dll</URL>
-        </URLs>
-        <Type>Component</Type>
-        <Description>IGT is available (by Kohru)</Description>
-        <Website>https://github.com/Jorkoh/LiveSplit.Minecraft</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Midtown Madness 2</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
I can no longer maintain this component and the community is transitioning into new timing methods so I'm leaving the game up for grabs.
