### PR TITLE
Updating Pepsiman Auto-Splitter URL

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11885,10 +11885,10 @@
 			<Game>Pepsiman</Game>
 		</Games>
 		<URLs>
-			<URL>https://raw.githubusercontent.com/MrMonsh/Auto-Splitters/main/Pepsiman/Pepsiman%20Auto-Splitter.asl</URL>
+			<URL>https://raw.githubusercontent.com/MrMonsh/Auto-Splitters/main/Pepsiman/Pepsiman_Auto-Splitter.asl</URL>
 		</URLs>
 		<Type>Script</Type>
-		<Description>Pepsiman Auto-Splitter &amp; Load Remover (by MrMonsh)</Description>
+		<Description>Pepsiman Auto-Splitter and Load Remover (by MrMonsh)</Description>
 		<Website>https://github.com/MrMonsh/Auto-Splitters/blob/main/Pepsiman/readme.txt</Website>
 	</AutoSplitter>
 	<AutoSplitter>


### PR DESCRIPTION
"Pepsiman Auto-Splitter,asl" had a space in its name, which didn't look very nice when downloaded. Re-uploaded the file to my repo with an underscore instead of a space and changed the url here for my peace of mind.

Also the description had an ampersand that wasn't showing correctly, so I just changed it for a regular "and". Minor stuff really.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
