### PR TITLE
Updating Pepsiman Auto-Splitter URL and info

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11885,11 +11885,11 @@
 			<Game>Pepsiman</Game>
 		</Games>
 		<URLs>
-			<URL>https://raw.githubusercontent.com/MrMonsh/Auto-Splitters/main/Pepsiman/Pepsiman%20Auto-Splitter.asl</URL>
+			<URL>https://raw.githubusercontent.com/MrMonsh/Auto-Splitters/main/Pepsiman/Pepsiman_Auto-Splitter.asl</URL>
 		</URLs>
 		<Type>Script</Type>
-		<Description>Pepsiman Auto-Splitter &amp; Load Remover (by MrMonsh)</Description>
-		<Website>https://github.com/MrMonsh/Auto-Splitters/blob/main/Pepsiman/readme.txt</Website>
+		<Description>Pepsiman Auto-Splitter and Load Remover (by MrMonsh)</Description>
+		<Website>https://github.com/MrMonsh/Auto-Splitters/tree/main/Pepsiman</Website>
 	</AutoSplitter>
 	<AutoSplitter>
 		<Games>


### PR DESCRIPTION
- "Pepsiman Auto-Splitter,asl" had a space in its name, which didn't look very nice when downloaded. Re-uploaded the file to my repo with an underscore instead of a space and changed the url here for my peace of mind.
- The description had an ampersand that wasn't showing correctly, so I just changed it for a regular "and". 
- Changed the URL for website to point to the "pretty-print" version of the readme instead of the raw version.

Minor stuff really.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
