### PR TITLE
Added DEADBOLT Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11903,5 +11903,16 @@
 		<Description>IGT is available.</Description>
 		<Website>https://github.com/LiveSplit/LiveSplit.Minecraft</Website>
 	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
+			<Game>DEADBOLT</Game>
+		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/PhoenixStroh/deadbolt-autosplitter/stable-main/Deadbolt_Any%25.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>Full Autosplitting by GameKwng</Description>
+		<Website>https://github.com/PhoenixStroh/deadbolt-autosplitter/tree/stable-main</Website>
+	</AutoSplitter>
 </AutoSplitters>
 


### PR DESCRIPTION
The autosplitter is an asl file, with an Automatic Start, a Split for each level and a Split for the ending. The autosplitter uses the v1.0.2 of Deadbolt only. This is the first autosplitter for DEADBOLT, and I have been working with the DEADBOLT community to make it.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ x ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ x ] The Auto Splitter has an open source license that allows anyone to fork and host it.
