### PR TITLE
Added Evoland 1 (Legendary Edition)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11934,5 +11934,16 @@
         <Description>Load removal (by JeffTheBigLizard)</Description>
         <Website>https://github.com/rodg/drakenier-splitters</Website>
     </AutoSplitter>
+	<AutoSplitter>
+		<Games>
+        		<Game>Evoland</Game>
+    		</Games>
+    		<URLs>
+        		<URL>https://raw.githubusercontent.com/Zatura24/LiveSplit.Autosplitters/main/Evoland%201%20-%20Legendary%20Edition/evoland-1.asl</URL>
+    		</URLs>
+    		<Type>Script</Type>
+    		<Description>Evoland 1 (Legendary Edition) Autosplitter (by Zatura24)</Description>
+		<Website>https://github.com/Zatura24/LiveSplit.Autosplitters/tree/main/Evoland%201%20-%20Legendary%20Edition</Website>
+	</AutoSplitter>
 </AutoSplitters>
 


### PR DESCRIPTION
Added my implementation of the Evoland 1 autosplitter made for the Legendary Edition version. Since this is the only version still available for purchase there is no reason to implement it for the original version.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)

- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
