### PR TITLE
Add King's Quest VI autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11945,5 +11945,16 @@
     		<Description>Evoland 1 (Legendary Edition) Autosplitter (by Zatura24)</Description>
 		<Website>https://github.com/Zatura24/LiveSplit.Autosplitters/tree/main/Evoland%201%20-%20Legendary%20Edition</Website>
 	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
+			<Game>King's Quest VI: Heir Today, Gone Tomorrow</Game>
+		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/dglynch/kq6-autosplitter/master/kq6.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>Configurable autosplitter for Any%, 100%, and Long Path categories. Requires DOSBox ECE.</Description>
+		<Website>https://github.com/dglynch/kq6-autosplitter</Website>
+	</AutoSplitter>
 </AutoSplitters>
 


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
