### PR TITLE
Days Gone .asl

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
 	<AutoSplitter>
 		<Games>
+        		<Game>Days Gone</Game>
+    		</Games>
+    		<URLs>
+        		<URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.DaysGone/main/DaysGone.asl</URL>
+    		</URLs>
+    		<Type>Script</Type>
+    		<Description>Days Gone load remover and autosplitter - pauses on loading screens, autostarts on first cutscene, autosplits on listed objectives (by Meta)</Description>
+		<Website>https://discord.gg/dYnQ5BH</Website>
+	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
         		<Game>Clive Barker's Undying</Game>
     		</Games>
     		<URLs>


### PR DESCRIPTION
Days Gone load remover and autosplitter - pauses on loading screens, autostarts on first cutscene, autosplits on listed objectives.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
