### PR TITLE
Update TR2 splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6704,13 +6704,14 @@
     <AutoSplitter>
         <Games>
             <Game>Tomb Raider II</Game>
+            <Game>Tomb Raider 2</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/FluxMonkii/Autosplitters/master/TombRaiderII.asl</URL>
+            <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderII/Component/TR2.dll</URL>
         </URLs>
-        <Type>Script</Type>
-        <Description>Autostart, split and reset available for full-game runs - Supports all known executables. (by FluxMonkii)</Description>
-        <Website>https://github.com/FluxMonkii/Autosplitters</Website>
+        <Type>Component</Type>
+        <Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions - by Midge &amp; rtrger</Description>
+        <Website>https://github.com/TombRunners/Autosplitters</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Failed to reach original script author for updates or approvals (last update ~ 3.5 years ago), so we created a new component from scratch. Supports FG, IL, and deathruns for all leaderboard-approved PC game versions.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
