### PR TITLE
Description change for Days Gone

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8,7 +8,7 @@
         		<URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.DaysGone/main/DaysGone.asl</URL>
     		</URLs>
     		<Type>Script</Type>
-    		<Description>Days Gone load remover and autosplitter - pauses on loading screens, autostarts on first cutscene, autosplits on listed objectives (by Meta)</Description>
+    		<Description>Days Gone load remover and autosplitter (by Meta)</Description>
 		<Website>https://discord.gg/dYnQ5BH</Website>
 	</AutoSplitter>
 	<AutoSplitter>
@@ -6704,14 +6704,13 @@
     <AutoSplitter>
         <Games>
             <Game>Tomb Raider II</Game>
-            <Game>Tomb Raider 2</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderII/Component/TR2.dll</URL>
+            <URL>https://raw.githubusercontent.com/FluxMonkii/Autosplitters/master/TombRaiderII.asl</URL>
         </URLs>
-        <Type>Component</Type>
-        <Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions - by Midge &amp; rtrger</Description>
-        <Website>https://github.com/TombRunners/Autosplitters</Website>
+        <Type>Script</Type>
+        <Description>Autostart, split and reset available for full-game runs - Supports all known executables. (by FluxMonkii)</Description>
+        <Website>https://github.com/FluxMonkii/Autosplitters</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
original text was cut off inside Livesplit, just shortened the description to fix it

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X ] The Auto Splitter has an open source license that allows anyone to fork and host it.
