### PR TITLE
Add autosplitters for Yakuza 0 and Kiwami

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2402,6 +2402,28 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Yakuza 0</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/drtchops/asl/master/yakuza0.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitting and Load Removal is available. (By ToxicTT and DrTChops)</Description>
+        <Website>https://github.com/drtchops/asl/blob/master/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Yakuza Kiwami</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/drtchops/asl/master/yakuza_kiwami.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitting and Load Removal is available. (By ToxicTT and DrTChops)</Description>
+        <Website>https://github.com/drtchops/asl/blob/master/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Penumbra: Black Plague</Game>
             <Game>Penumbra Black Plague</Game>
             <Game>Black Plague</Game>


### PR DESCRIPTION
Auto splitting done by ToxicTT, load removal done by DrTChops

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
