### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -12268,7 +12268,7 @@
 	</AutoSplitter>
 	<AutoSplitter>
 		<Games>
-			<Game>Resident Evil 2 (1998)</Game>
+			<Game>Resident Evil 2</Game>
 		</Games>
 		<URLs>
 			<URL>https://raw.githubusercontent.com/CarcinogenSDA/re2-classic-autosplitter/main/re2_autosplitter_all_doors.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -12274,7 +12274,7 @@
 			<URL>https://raw.githubusercontent.com/CarcinogenSDA/re2-classic-autosplitter/main/re2_autosplitter_all_doors.asl</URL>
 		</URLs>
 		<Type>Script</Type>
-		<Description>Resident Evil 2 Classic PC All Doors Autosplitter for use with Sourcenext 1.10 and RE2 Classic REbirth (by CarcinogenSDA)</Description>
+		<Description>All Doors Autosplitter for use with Sourcenext 1.10 and RE2 Classic REbirth (by CarcinogenSDA)</Description>
 		<Website>https://github.com/CarcinogenSDA/re2-classic-autosplitter</Website>
 	</AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
minus the "1998", because I put it in by mistake and it broke everything

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [Y] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [Y] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [Y] The Auto Splitter has an open source license that allows anyone to fork and host it.
