### PR TITLE
Sunblaze autosplitter added

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11663,7 +11663,7 @@
             <URL>https://raw.githubusercontent.com/sseneca42/Outer-Wilds-Autosplitter/main/OW_Autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Remover &amp; AutoSplitter (by Nepo)</Description>
+        <Description>Load Remover and AutoSplitter (by Nepo)</Description>
 	<Website>https://github.com/sseneca42/Outer-Wilds-Autosplitter/blob/main/README.md</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -12299,5 +12299,16 @@
       <Type>Script</Type>
       <Description>Auto-Splitting and Load Removal (by badBlackShark)</Description>
       <Website>https://github.com/badBlackShark/ASL-Scripts</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Sunblaze</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/sseneca42/Sunblaze-Autosplitter/main/Sunblaze_Autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter (by Nepo)</Description>
+	<Website>https://github.com/sseneca42/Sunblaze-Autosplitter</Website>
     </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
 Autosplitter added for Sunblaze and Outer Wilds description fixed.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
