### PR TITLE
Add Slime Rancher Category Extensions

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6829,6 +6829,7 @@
     <AutoSplitter>
         <Games>
             <Game>Slime Rancher</Game>
+            <Game>Slime Rancher Category Extensions</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/supra0/slime-rancher-autosplitter/master/SlimeRancher.asl</URL>


### PR DESCRIPTION
Slime Rancher was previously missing its Category Extensions in its games list

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ x ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ x ] The Auto Splitter has an open source license that allows anyone to fork and host it.
