### PR TITLE
added Harry Potter 6 PC support

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8165,6 +8165,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Harry Potter and the Half Blood Prince</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/xLink/hp6-autosplitter/main/hp6_autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Supports autosplitter that splits automatically between levels and at the end of the run.</Description>
+        <Website>https://github.com/xLink/hp6-autosplitter/</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Harry Potter and the Deathly Hallows Part 1</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Adds auto splitter functionality for the HP6 PC game

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
