### PR TITLE
Changing amperstand to 'and'

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8888,7 +8888,7 @@
             <URL>https://raw.githubusercontent.com/MrLette/ControlAutoSplitter/main/Control.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto start/split/end and load removal (by MrLette &amp; derwangler)</Description>
+        <Description>Auto start/split/end and load removal (by MrLette and derwangler)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Amperstadn does not display correctly in LiveSplit GUI. Changing for a fully spelled 'and'. Sorry for the inconvenience.