### PR TITLE
Make TrackMania Forever splitter appear for TMXCC

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5049,6 +5049,7 @@
         <Games>
             <Game>TrackMania Nations Forever</Game>
             <Game>TrackMania United Forever</Game>
+            <Game>TMX Community Campaign</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/donadigo/AutoSplitters/master/Trackmania%20Forever.asl</URL>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Makes Trackmania Nations/United Forever splitter (which I'm the author of) appear for the game "TMX Community Campaign" (https://www.speedrun.com/tmxcc).