### PR TITLE
Update Minecraft: Java Edition to latest game ver.

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -12288,8 +12288,8 @@
             <Game>Minecraft: Java Edition</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/LiveSplit/LiveSplit.Minecraft/master/Components/LiveSplit.Minecraft.dll</URL>
-            <URL>https://raw.githubusercontent.com/LiveSplit/LiveSplit.Minecraft/master/Components/fNbt.dll</URL>
+            <URL>https://raw.githubusercontent.com/qwertyuioplkjhgfd/LiveSplit.Minecraft/master/Components/LiveSplit.Minecraft.dll</URL>
+            <URL>https://raw.githubusercontent.com/qwertyuioplkjhgfd/LiveSplit.Minecraft/master/Components/fNbt.dll</URL>
         </URLs>
         <Type>Component</Type>
         <Description>IGT is available.</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -12293,7 +12293,7 @@
         </URLs>
         <Type>Component</Type>
         <Description>IGT is available.</Description>
-        <Website>https://github.com/LiveSplit/LiveSplit.Minecraft</Website>
+        <Website>https://github.com/qwertyuioplkjhgfd/LiveSplit.Minecraft</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Previous Autosplitter/IGT did not work on the latest version of Minecraft and is unmaintained

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
