### PR TITLE
Replace Madzinah LOVE splitter with majoneesi

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1965,10 +1965,10 @@
             <Game>Love+</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/madzinah/LiveSplits_Scripts/master/Love.asl</URL>
+            <URL>https://raw.githubusercontent.com/neesi/autosplitters/master/LOVE/LOVE_livesplit.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Automatic Timer Start and Auto Splitting is available. (By Madzinah)</Description>
+        <Description>Automatic Timer Start and Auto Splitting is available. Splitter by majoneesi.</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
The old autosplitter was broken, majoneesi's version works properly with the latest update.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x ] The Auto Splitter has an open source license that allows anyone to fork and host it.

Discussed with the game's moderator