### PR TITLE
Legacy of Kain: Defiance autosplitter update

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3850,7 +3850,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Legacy of Kain : Defiance</Game>
+            <Game>Legacy of Kain: Defiance</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/blastedt/asl/master/LegacyOfKainDefiance.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3853,11 +3853,10 @@
             <Game>Legacy of Kain: Defiance</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/blastedt/asl/master/LegacyOfKainDefiance.asl</URL>
+            <URL>https://raw.githubusercontent.com/thekovic/LoK-Defiance-Autosplitter/main/defiance6.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto Splitting and Start/Reset are available (By TheDuriel + blastedt)</Description>
-        <Website>https://github.com/blastedt/asl/blob/master/README.md</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
The previous URL linked to out-of-date script in an inactive user's repository. I uploaded the latest version of the script with author's (TheDuriel) permission and changed the link to that. I also fixed a typo in the game's name

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
