### PR TITLE
Adding RICO and adding credit for APT

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -31,7 +31,7 @@
             <URL>https://raw.githubusercontent.com/KunoDemetries/AutoSplitter/master/RICO.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto plitter/ Load Remover (by xZeko, Kuno Demetries)</Description>
+        <Description>Auto Splitter/ Load Remover (by xZeko, Kuno Demetries)</Description>
 	<Website>https://discord.gg/s3KBdU8uB9</Website>
     </AutoSplitter>
     <AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23,6 +23,17 @@
         <Description>Facility47 ASL written by xconspirisist / James Read. Functionality for start, and splitting on key scenes.</Description>
 	<Website>https://www.speedrun.com/facility_47</Website>
     </AutoSplitter>
+	    <AutoSplitter>
+        <Games>
+            <Game>RICO</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/KunoDemetries/AutoSplitter/master/RICO.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto plitter/ Load Remover (by xZeko, Kuno Demetries)</Description>
+	<Website>https://discord.gg/s3KBdU8uB9</Website>
+    </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>A Plague Tale: Innocence</Game>
@@ -31,7 +42,7 @@
             <URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.APlagueTaleInnocence/main/APlagueTaleInnocence.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>A Plague Tale ASL with functionality for load removal and autostart by Meta</Description>
+        <Description>A Plague Tale ASL with functionality for load removal and autostart (by Meta, Kuno Demetries)</Description>
         <Website>https://discord.gg/ANz4Ue4</Website>
     </AutoSplitter>
  <AutoSplitter>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ x] The Auto Splitter has an open source license that allows anyone to fork and host it.

zeko is the mod for rico but never pull requested it onto livesplit and I helped with loading, the game is just jank lol. 
Meta said it was cool for me to add credit for A Plague's Tail as I did the entire split method