### PR TITLE
Add the The Heat of War load remover and autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2302,6 +2302,12 @@
             <Game>Star Trek: Klingon Honor Guard</Game>
             <Game>Star Trek Klingon Honor Guard</Game>
             <Game>Klingon Honor Guard</Game>
+	    <Game>THOW</Game>
+	    <Game>The Heat Of War</Game>
+	    <Game>WWII Combat - Iwo Jima</Game>
+	    <Game>WWII Combat: Iwo Jima</Game>
+	    <Game>Iwo Jima</Game>
+	    <Game>WWII Combat</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Dalet/LiveSplit.UnrealLoads/master/Components/LiveSplit.UnrealLoads.dll</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2302,12 +2302,11 @@
             <Game>Star Trek: Klingon Honor Guard</Game>
             <Game>Star Trek Klingon Honor Guard</Game>
             <Game>Klingon Honor Guard</Game>
-	    <Game>THOW</Game>
-	    <Game>The Heat Of War</Game>
-	    <Game>WWII Combat - Iwo Jima</Game>
-	    <Game>WWII Combat: Iwo Jima</Game>
-	    <Game>Iwo Jima</Game>
-	    <Game>WWII Combat</Game>
+            <Game>The Heat Of War</Game>
+            <Game>WWII Combat - Iwo Jima</Game>
+            <Game>WWII Combat: Iwo Jima</Game>
+            <Game>Iwo Jima</Game>
+            <Game>WWII Combat</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Dalet/LiveSplit.UnrealLoads/master/Components/LiveSplit.UnrealLoads.dll</URL>


### PR DESCRIPTION
The game "The Heat of War" was also released under the name "WWII Combat: Iwo Jima". Dalet confirmed the PR to his component is fine, and reminded to PR to LiveSplit.AutoSplitters as well.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
