### PR TITLE
Changed autosplitter for Sonic Colors from .asl to .dll component

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1457,7 +1457,7 @@
             <Game>Sonic Colours: Ultimate</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/Jujstme/Autosplitters/master/Sonic%20Colors%20Ultimate/SonicColorsUltimate.asl</URL>
+            <URL>https://github.com/Jujstme/Autosplitters/raw/master/Sonic%20Colors%20Ultimate/Components/LiveSplit.SonicColors.dll</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting and In-Game Timer are available (by Jujstme)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1459,7 +1459,7 @@
         <URLs>
             <URL>https://raw.githubusercontent.com/Jujstme/Autosplitters/master/Sonic%20Colors%20Ultimate/Components/LiveSplit.SonicColors.dll</URL>
         </URLs>
-        <Type>Script</Type>
+        <Type>Component</Type>
         <Description>Autosplitting and In-Game Timer are available (by Jujstme)</Description>
         <Website>https://discord.gg/XRsRwRU</Website>
     </AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1457,7 +1457,7 @@
             <Game>Sonic Colours: Ultimate</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/Jujstme/Autosplitters/raw/master/Sonic%20Colors%20Ultimate/Components/LiveSplit.SonicColors.dll</URL>
+            <URL>https://raw.githubusercontent.com/Jujstme/Autosplitters/master/Sonic%20Colors%20Ultimate/Components/LiveSplit.SonicColors.dll</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting and In-Game Timer are available (by Jujstme)</Description>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
