### PR TITLE
Updated Deathloop autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13165,9 +13165,10 @@
 		    <Game>DEATHLOOP</Game>
 		</Games>
 		<URLs>
-		    <URL>https://raw.githubusercontent.com/Micrologist/Livesplit.Deathloop/main/deathloop.asl</URL>
+		    <URL>https://raw.githubusercontent.com/Jujstme/Livesplit.Deathloop/local/Components/LiveSplit.Deathloop.dll</URL>
 		</URLs>
-		<Type>Script</Type>
-		<Description>Auto Splitting and Load Removal available. (By Micrologist#2351)</Description>
+		<Type>Component</Type>
+		<Description>Auto Splitting and Load Removal available. (By Micrologist#2351 and Jujstme)</Description>
+	        <Website>https://github.com/Jujstme/LiveSplit.Deathloop</Website>
     	</AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Updated to dll component and tweaked the timing logic as the previous version ended up mismanaging the gametime, creating issues with players.
The previous owner (Micrologist) agreed on Discord for the replacement of the script (he has also been added as a collaborator to the new one).

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
