### PR TITLE
Added autosplitter for WALL-E (PC)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13194,4 +13194,15 @@
 		<Description>Auto Splitting and Load Removal available. (By Micrologist#2351 and Jujstme)</Description>
 	        <Website>https://github.com/Jujstme/LiveSplit.Deathloop</Website>
     	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
+		    <Game>WALL-E (PC/PS2/PSP)</Game>
+		</Games>
+		<URLs>
+		    <URL>https://raw.githubusercontent.com/luis-trueba/wallepc_autosplitter/main/wall-e_autosplit.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>Auto Splitting (with or without mid-level subsplits) and Load Removal available for PC version only. Consult the leaderboard rules for load removal legality. (By RoboticRocketeer)</Description>
+	        <Website>https://github.com/luis-trueba/wallepc_autosplitter</Website>
+    	</AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [✅] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [✅] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [✅] The Auto Splitter has an open source license that allows anyone to fork and host it.
