### PR TITLE
Added Ace Combat 7 autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13228,4 +13228,15 @@
         <Description>AutoSplitter measuring game time, load times and auto-resets (by Ciel DeVille and AnqiX)</Description>
         <Website>https://github.com/cieldeville/LiveSplit.TOEM</Website>
     </AutoSplitter>
+	<AutoSplitter>
+		<Games>
+		    <Game>Ace Combat 7</Game>
+		</Games>
+		<URLs>
+		    <URL>https://raw.githubusercontent.com/CptPie/AC7_Autosplit/main/ac7.asl</URL>
+		</URLs>
+		<Type>Component</Type>
+		<Description>Auto Splitting (with or without mid-level subsplits) as well as the ability to detect S-Ranks and split on S-Ranks only.</Description>
+	        <Website>https://github.com/CptPie/AC7_Autosplit</Website>
+    	</AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
