### PR TITLE
Include SNES Top Gear autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
-	<AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Top Gear</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/pedro-walter/topgear-autosplitter/main/topgear.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Automatically splits when crossing each finish line. Works for single-player only.</Description>
+    </AutoSplitter>		
+    <AutoSplitter>
         <Games>
             <Game>Need for Speed: Undercover</Game>
         </Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
