### PR TITLE
Replace Trackmania Turbo autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5389,10 +5389,10 @@
             <Game>TrackMania Turbo</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/NeKzor/ASL-Scripts/master/TrackmaniaTurbo.asl</URL>
+            <URL>https://raw.githubusercontent.com/Voyager006/Autosplitters/master/TrackmaniaTurbo/TrackmaniaTurbo.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load remover and auto splitting options are available. (By NeKz)</Description>
+        <Description>In-game time + auto start/reset/split options are available. (By Voyager006 and donadigo)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Complete rewrite of the TMTurbo autosplitter with updated URL and description. With approval from NeKz, the original author.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
