### PR TITLE
Add "DOOM Eternal: The Ancient Gods - Part Two"

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4183,6 +4183,7 @@
             <Game>DoomEternal</Game>
             <Game>Doom Eternal</Game>
             <Game>DOOM Eternal: The Ancient Gods - Part One</Game>
+            <Game>DOOM Eternal: The Ancient Gods - Part Two</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/loitho/doom-eternal/master/doometernal.asl</URL>


### PR DESCRIPTION
Adds the second DLC to DOOM Eternal's autosplitter game list.

- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
