### PR TITLE
Added Exo One auto splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1209,6 +1209,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Exo One</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/just-ero/AutoSplitTools/master/Exo%20One/EXO_ONE.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Starts automatically. Splits when warping. Syncs to level-completion time upon warping. (by Ero)</Description>
+        <Website>https://github.com/just-ero/AutoSplitTools/tree/master/Exo%20One</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>The Final Station</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
