### PR TITLE
Update outdated (non-functional) Genshin Impact autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11550,11 +11550,11 @@
             <Game>Genshin Impact</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/KhanSimeoni/GenshinImpactAutosplit/main/GenshinImpactLoadRemover.asl</URL>
+            <URL>https://raw.githubusercontent.com/saiamphora/GenshinImpact-LTR/main/GenshinImpactLTR.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Website>https://github.com/KhanSimeoni/GenshinImpactAutosplit</Website>
-        <Description>Load time remover for Genshin Impact</Description>
+        <Website>https://github.com/saiamphora/GenshinImpact-LTR</Website>
+        <Description>Load time remover for Genshin Impact.</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [/ ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ /] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ /] The Auto Splitter has an open source license that allows anyone to fork and host it.

I'm overwriting this non functional autosplitter with permission from the author.