### PR TITLE
Added TR2 Gold and improved other classic TR game searches by adding name variations.

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7462,7 +7462,6 @@
 			<Game>TR2 Gold</Game>
 			<Game>TRII: Golden Mask</Game>
 			<Game>TR2: Golden Mask</Game>
-			<Game>Classic Tomb Raider Category Extensions</Game>
 		</Games>
 		<URLs>
 			<URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderIIGold/Components/TR2Gold.dll</URL>
@@ -9182,9 +9181,11 @@
     <AutoSplitter>
         <Games>
 	        <Game>Tomb Raider I</Game>
+	        <Game>Tomb Raider 1</Game>
 	        <Game>Tomb Raider</Game>
 	        <Game>Tomb Raider (1996)</Game>
 	        <Game>TRI</Game>
+	        <Game>TR1</Game>
 	        <Game>TR</Game>
 	        <Game>TR1996</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9181,12 +9181,12 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Tomb Raider I</Game>
+	        <Game>Tomb Raider I</Game>
 	        <Game>Tomb Raider</Game>
 	        <Game>Tomb Raider (1996)</Game>
-			<Game>TRI</Game>
+	        <Game>TRI</Game>
 	        <Game>TR</Game>
-			<Game>TR1996</Game>
+	        <Game>TR1996</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaider1996/Components/TR1996.dll</URL>
@@ -12115,14 +12115,14 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-			<Game>Tomb Raider III: Adventures of Lara Croft</Game>
+	        <Game>Tomb Raider III: Adventures of Lara Croft</Game>
 	        <Game>Tomb Raider 3: Adventures of Lara Croft</Game>
 	        <Game>Tomb Raider III</Game>
-			<Game>Tomb Raider 3</Game>
+	        <Game>Tomb Raider 3</Game>
 	        <Game>TRIII: Adventures of Lara Croft</Game>
 	        <Game>TR3: Adventures of Lara Croft</Game>
-			<Game>TRIII</Game>
-			<Game>TR3</Game>
+	        <Game>TRIII</Game>
+	        <Game>TR3</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/LiveSplit.TR3.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7441,15 +7441,36 @@
         <Games>
             <Game>Tomb Raider II</Game>
             <Game>Tomb Raider 2</Game>
+	        <Game>TRII</Game>
+	        <Game>TR2</Game>
             <Game>Classic Tomb Raider Category Extensions</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderII/Components/TR2.dll</URL>
         </URLs>
         <Type>Component</Type>
-        <Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions - by Midge &amp; rtrger</Description>
+        <Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions - by Midge and rtrger</Description>
         <Website>https://github.com/TombRunners/Autosplitters</Website>
     </AutoSplitter>
+	<AutoSplitter>
+		<Games>
+			<Game>Tomb Raider II Gold</Game>
+			<Game>Tomb Raider 2 Gold</Game>
+			<Game>Tomb Raider II: Golden Mask</Game>
+			<Game>Tomb Raider 2: Golden Mask</Game>
+			<Game>TRII Gold</Game>
+			<Game>TR2 Gold</Game>
+			<Game>TRII: Golden Mask</Game>
+			<Game>TR2: Golden Mask</Game>
+			<Game>Classic Tomb Raider Category Extensions</Game>
+		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderIIGold/Components/TR2Gold.dll</URL>
+		</URLs>
+		<Type>Component</Type>
+		<Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions - by Midge and rtrger</Description>
+		<Website>https://github.com/TombRunners/Autosplitters</Website>
+	</AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Chip 'N Dale: Rescue Rangers</Game>
@@ -9160,7 +9181,12 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Tomb Raider</Game>
+            <Game>Tomb Raider I</Game>
+	        <Game>Tomb Raider</Game>
+	        <Game>Tomb Raider (1996)</Game>
+			<Game>TRI</Game>
+	        <Game>TR</Game>
+			<Game>TR1996</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaider1996/Components/TR1996.dll</URL>
@@ -12089,10 +12115,14 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Tomb Raider 3</Game>
-            <Game>Tomb Raider III</Game>
-            <Game>Tomb Raider III: Adventures of Lara Croft</Game>
-            <Game>Tomb Raider 3: Adventures of Lara Croft</Game>
+			<Game>Tomb Raider III: Adventures of Lara Croft</Game>
+	        <Game>Tomb Raider 3: Adventures of Lara Croft</Game>
+	        <Game>Tomb Raider III</Game>
+			<Game>Tomb Raider 3</Game>
+	        <Game>TRIII: Adventures of Lara Croft</Game>
+	        <Game>TR3: Adventures of Lara Croft</Game>
+			<Game>TRIII</Game>
+			<Game>TR3</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/LiveSplit.TR3.asl</URL>


### PR DESCRIPTION
Added TR2 Gold and improved other classic TR game searches by adding name variations.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
