### PR TITLE
add mono xml for Gunfire Reborn

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1305,6 +1305,7 @@
             <Game>Gunfire Reborn</Game>
         </Games>
         <URLs>
+	    <URL>https://raw.githubusercontent.com/just-ero/AutoSplitHelp/master/mono/mono_il2cpp_2019_x64.xml</URL>
             <URL>https://raw.githubusercontent.com/just-ero/AutoSplitTools/master/Gunfire%20Reborn/GunfireReborn.asl</URL>
         </URLs>
         <Type>Script</Type>


### PR DESCRIPTION
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
