### PR TITLE
Fix SourceSplit fork's URL

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4282,7 +4282,7 @@
             <Game>Portal: Elevators</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/thisis2838/SourceSplit/raw/master/update/LiveSplit.SourceSplit.dll</URL>
+            <URL>https://raw.githubusercontent.com/thisis2838/SourceSplit/master/update/Components/LiveSplit.SourceSplit.dll</URL>
         </URLs>
         <Type>Component</Type>
         <ShowInLayoutEditor />


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ v] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [v ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ v] The Auto Splitter has an open source license that allows anyone to fork and host it.
