### PR TITLE
switch Gunfire Reborn url order

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1305,8 +1305,8 @@
             <Game>Gunfire Reborn</Game>
         </Games>
         <URLs>
-	    <URL>https://raw.githubusercontent.com/just-ero/AutoSplitHelp/master/mono/mono_il2cpp_2019_x64.xml</URL>
             <URL>https://raw.githubusercontent.com/just-ero/AutoSplitTools/master/Gunfire%20Reborn/GunfireReborn.asl</URL>
+	    <URL>https://raw.githubusercontent.com/just-ero/AutoSplitHelp/master/mono/mono_il2cpp_2019_x64.xml</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Starts, resets automatically. Splits available in the settings. Pauses when dying. (by Ero)</Description>


### PR DESCRIPTION
How does this actually work? With the other way around, users who activated this auto splitter had the mono XML file set as their ASL file path in the auto splitter settings. Is it merely decided by the order which file is set as the ASL file path? Or is it perhaps the first file which finishes downloading?