### PR TITLE
Added Autosplitter for Sonic's Schoolhouse

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13857,4 +13857,15 @@
 		<Description>Autosplitter with LRT by Mysterion_06_</Description>
 		<Website>https://github.com/Mysterion06/FF7RSplitter/blob/main/README.md</Website>
 	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
+			<Game>Sonic's Schoolhouse</Game>
+		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/SpectralPlatypus/AutoSplitters/master/SonicSH.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>Autosplitter for Sonic's Schoolhouse (by SpectralPlatypus)</Description>
+		<Website>https://www.speedrun.com/sonics_schoolhouse</Website>
+	</AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
