### PR TITLE
Add OpenTTD autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13868,4 +13868,18 @@
 		<Description>Autosplitter for Sonic's Schoolhouse (by SpectralPlatypus)</Description>
 		<Website>https://www.speedrun.com/sonics_schoolhouse</Website>
 	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
+			<Game>OpenTTD</Game>
+			<Game>OpenTTD 1.11.2</Game>
+			<Game>OpenTTD 1.12.1</Game>
+			<Game>OpenTTD 12.1</Game>
+		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/yaram/openttd-autosplitter/master/OpenTTD.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>Autosplitting, Autostart, Auto Reset for OpenTTD (by Yaram)</Description>
+		<Website>https://github.com/yaram/openttd-autosplitter</Website>
+	</AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Supports autosplitting on payed loan, 1mil money, and 90% & 100% total score.
Also supports auto reset in menu and autostart after world load/generation.

Supports 1.11.2 and 1.12.1 (AKA 12.1)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
