### PR TITLE
Add Eye of the Temple to AutoSplitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14144,4 +14144,14 @@
         <Website>https://github.com/ZywelZill/zywel-zill-autosplitters</Website>
         <Description>AutoSplitter By Zywel Zill)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Eye of the Temple</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/runevision/EyeOfTheTempleAutoSplitter/main/EyeOfTheTemple.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Loadless timer based on in-game time. (By runevision)</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Hi, I'm the developer of Eye of the Temple and I made this simple autosplitter based on the in-game timer.

I don't know if or how speedrunners might want to split their runs so it only splits when the timer stops for now. However, there's info in the ASL file that others could use to extend its functionality if they want.