### PR TITLE
Add TRUtil DLLs to TRs 1-3 and combine TR2 and TR2 Gold.

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7628,17 +7628,6 @@
             <Game>Tomb Raider 2</Game>
             <Game>TRII</Game>
             <Game>TR2</Game>
-            <Game>Classic Tomb Raider Category Extensions</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderII/Components/TR2.dll</URL>
-        </URLs>
-        <Type>Component</Type>
-        <Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions - by Midge and rtrger</Description>
-        <Website>https://github.com/TombRunners/Autosplitters</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Tomb Raider II Gold</Game>
             <Game>Tomb Raider 2 Gold</Game>
             <Game>Tomb Raider II: Golden Mask</Game>
@@ -7649,10 +7638,10 @@
             <Game>TR2: Golden Mask</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderIIGold/Components/TR2Gold.dll</URL>
+            <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderII/Components/TR2.dll</URL>
         </URLs>
         <Type>Component</Type>
-        <Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions - by Midge and rtrger</Description>
+        <Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions for TR2 and TR2 Gold - by Midge and rtrger</Description>
         <Website>https://github.com/TombRunners/Autosplitters</Website>
     </AutoSplitter>
     <AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7639,6 +7639,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderII/Components/TR2.dll</URL>
+		    <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderII/Components/TRUtil.dll</URL>
         </URLs>
         <Type>Component</Type>
         <Description>Automatic start, split and reset for FG, IL, and deathruns of leaderboard-approved versions for TR2 and TR2 Gold - by Midge and rtrger</Description>
@@ -9366,6 +9367,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaider1996/Components/TR1996.dll</URL>
+		    <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaider1996/Components/TRUtil.dll</URL>
         </URLs>
         <Type>Component</Type>
         <Description>Automatic start, split, and reset are available, as well as an IL timer and IGT display. (by Midge, rtrger, Lowosos, RiiFT)</Description>
@@ -12308,6 +12310,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderIII/Components/TR3.dll</URL>
+			<URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TombRaiderIII/Components/TRUtil.dll</URL>
         </URLs>
         <Type>Component</Type>
         <Description>Automatic start, split, reset, and IGT for FG, IL, and deathruns. By apel, Danza, Midge, rr-, rtrger</Description>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.