### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13451,7 +13451,7 @@
             <URL>https://raw.githubusercontent.com/Marek2810/Vlak/main/vlak.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter for the Vlak on DOSBox 0.72. Split at the end of each level.</Description>
+        <Description>Autosplitter for the Vlak on DOSBox. Split at the end of each level.</Description>
         <Website>https://github.com/Marek2810/Vlak</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
Correcting text. Autosplitter works with some versions of DOSBox.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
