### PR TITLE
Updated Sonic CD (2011) autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6712,11 +6712,11 @@
             <Game>Sonic CD 2011</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/SonicSpeedrunning/LiveSplitASL/master/Sonic%20CD.asl</URL>
+            <URL>https://raw.githubusercontent.com/SonicSpeedrunning/LiveSplit.SonicCD2011/main/LiveSplit.SonicCD2011.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>For CD 2011 on Steam. Game Time - Mins and Secs, with ms added on final level.</Description>
-        <Website>https://github.com/SonicSpeedrunning/LiveSplitASL</Website>
+        <Description>Supports both Steam release and decompilation versions of Sonic CD (2011). Settings available.</Description>
+        <Website>https://github.com/SonicSpeedrunning/LiveSplit.SonicCD2011</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Added support for more versions of the game and improved game time calculation.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
