### PR TITLE
added Total War: Warhammer 3 auto splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14222,6 +14222,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Total War: WARHAMMER III</Game>
+            <Game>Total War: WARHAMMER 3</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/just-ero/asl/raw/main/Total%20War%20%E2%80%93%20WARHAMMER%20III/TotalWar_Warhammer3.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Removes loading times. (by Ero)</Description>
+        <Website>https://github.com/just-ero/asl/tree/main/Total%20War%20%E2%80%93%20WARHAMMER%20III</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Transformers: The Game</Game>
         </Games>
         <URLs>
@@ -14266,6 +14278,7 @@
         <Description>Starts, resets automatically. Splits available in the settings. (by Ero)</Description>
         <Website>https://github.com/just-ero/asl/tree/main/YAPP%20%E2%80%93%20Yet%20Another%20Puzzle%20Platformer</Website>
     </AutoSplitter>
+
     <AutoSplitter>
         <Games>
             <Game>Kao the Kangaroo Multiruns</Game>


### PR DESCRIPTION
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
