### PR TITLE
add Portal 2 Speedrun Mod

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1843,6 +1843,7 @@
         <Games>
             <Game>Aperture Tag</Game>
             <Game>Portal 2</Game>
+            <Game>Portal 2 Speedrun Mod</game>
             <Game>Portal Reloaded</Game>
             <Game>Portal Stories: Mel</Game>
             <Game>Thinking with Time Machine</Game>


### PR DESCRIPTION
P2SM is the only main Portal 2 Category that isn't available through LiveSplit's default autosplitter.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [✅] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [✅] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [✅] The Auto Splitter has an open source license that allows anyone to fork and host it.
