### PR TITLE
Replace elden ring game time plugin

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13777,16 +13777,20 @@
         <Type>Script</Type>
         <Description>RE Rev 2 Autosplitter - LRT Timed - Sub Chapter, DLC and Full Campaign Splitting - (by TheDementedSalad)</Description>
     </AutoSplitter>
-    <AutoSplitter>
+   <AutoSplitter>
         <Games>
             <Game>Elden Ring</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/dwonisch/LiveSplit.EldenRing/master/Components/LiveSplit.EldenRing.dll</URL>
+			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignColors.dll</URL>
+			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignThemes.Wpf.dll</URL>
+			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignThemes.Wpf.xml</URL>
+			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/SoulMemory.dll</URL>
+			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/SoulSplitter.dll</URL>
         </URLs>
         <Type>Component</Type>
-        <Description>GameTime for Elden Ring</Description>
-        <Website>https://github.com/dwonisch/LiveSplit.EldenRing</Website>
+        <Description>Modified in game time for Elden Ring</Description>
+        <Website>https://github.com/FrankvdStam/SoulSplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13777,16 +13777,16 @@
         <Type>Script</Type>
         <Description>RE Rev 2 Autosplitter - LRT Timed - Sub Chapter, DLC and Full Campaign Splitting - (by TheDementedSalad)</Description>
     </AutoSplitter>
-   <AutoSplitter>
+    <AutoSplitter>
         <Games>
             <Game>Elden Ring</Game>
         </Games>
         <URLs>
-			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignColors.dll</URL>
-			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignThemes.Wpf.dll</URL>
-			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignThemes.Wpf.xml</URL>
-			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/SoulMemory.dll</URL>
-			<URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/SoulSplitter.dll</URL>
+            <URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignColors.dll</URL>
+	    <URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignThemes.Wpf.dll</URL>
+	    <URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/MaterialDesignThemes.Wpf.xml</URL>
+            <URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/SoulMemory.dll</URL>
+            <URL>https://raw.githubusercontent.com/FrankvdStam/SoulSplitter/main/Components/SoulSplitter.dll</URL>
         </URLs>
         <Type>Component</Type>
         <Description>Modified in game time for Elden Ring</Description>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

I have not spoken to the author of the existing plugin about this replacement. It was however announced that this is the official timer for ER. You can find this in the speedsouls discord, in the announcement channel.

![image](https://user-images.githubusercontent.com/37239092/159157039-4e7789da-a1ca-44b5-8c73-2b30bd22b151.png)
