### PR TITLE
Adds Octopath Traveler

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,16 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Octopath Traveler</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Eein/octopath-autosplitter/main/octopath.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter (By Z3R01337 and SuperFamicom)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>SkiFree</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

This autosplitter was the work of the attributed, and mega thanks to Ero in the Speedrun Tools Discord for providing us with some insight on:

- UE4 Object lookups (still learning here)
- Code style for C#
- Recommending better optimizations
- Some verifications against UE4 objects

The autosplitter provides quite a few flags for various game modes including:
- Story Flags for all Single stories, still more to be added later on request, but the digits are consistent.
- Story Endings (Trigger endings for single story runs based on rule requirements for SRC)
- Zone (I think every?) enter/exit flags
- Encounter/Death counter (borrowed from FF9 autosplitter)
- Start End Timing
- Credits timing (no run uses it, but its there)
- Galdera Timing

We're happy to make any styling changes or optimizations as recommended.