### PR TITLE
Adding Little Big Adventure 2 autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14629,4 +14629,16 @@
         <Description>Auto start/split/reset supported (By CaptainRektbeard)</Description>
         <Website>https://github.com/samjones246/marblemarcher-asl</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Little Big Adventure 2 (Twinsen's Odyssey)</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/amanekko/little-big-adventure-2-ASL/main/Little%20Big%20Adventure%202%20(Twinsen's%20Odyssey)%20-%20Any%25%20(GOG).asl</URL>
+            <URL>https://raw.githubusercontent.com/amanekko/little-big-adventure-2-ASL/main/Little%20Big%20Adventure%202%20(Twinsen's%20Odyssey)%20-%20Any%25%20(Steam).asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start/split/reset for LBA2 on GOG & Steam versions.</Description>
+        <Website>https://github.com/amanekko/little-big-adventure-2-ASL</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14637,7 +14637,6 @@
             <URL>https://raw.githubusercontent.com/amanekko/little-big-adventure-2-ASL/main/Little%20Big%20Adventure%202%20(Twinsen's%20Odyssey)%20-%20Any%25%20(GOG).asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto start/split/reset for LBA2 on GOG & Steam versions.</Description>
-        <Website>https://github.com/amanekko/little-big-adventure-2-ASL</Website>
+        <Description>Auto start/split/reset for LBA2</Description>
     </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14635,7 +14635,6 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/amanekko/little-big-adventure-2-ASL/main/Little%20Big%20Adventure%202%20(Twinsen's%20Odyssey)%20-%20Any%25%20(GOG).asl</URL>
-            <URL>https://raw.githubusercontent.com/amanekko/little-big-adventure-2-ASL/main/Little%20Big%20Adventure%202%20(Twinsen's%20Odyssey)%20-%20Any%25%20(Steam).asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start/split/reset for LBA2 on GOG & Steam versions.</Description>


### PR DESCRIPTION
Adding Little Big Adventure 2 autosplitter for both Steam & GOG versions.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
