### PR TITLE
Adding The Stanley Parable: Ultra Deluxe and Dexter Stardust: Adventures in Outer Space Autosplitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,29 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>The Stanley Parable: Ultra Deluxe</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Nikoheartttv/TheStanleyParableUltraDeluxe_Autosplitter/main/TSPUD_AutoSplitter.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/libraries/UnityASL.bin</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by Nikoheart</Description>
+        <Website>https://www.speedrun.com/tspud</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Dexter Stardust: Adventures in Outer Space</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Nikoheartttv/DexterStardustAdventuresInOuterSpace_AutoSplitter/main/DexterStardust.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/libraries/UnityASL.bin</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by Nikoheart</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Mini Metro</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
adding The Stanley Parable: Ultra Deluxe and Dexter Stardust: Adventures in Outer Space autosplitter

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
