### PR TITLE
Add a new Path of Exile splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13,6 +13,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Path of Exile</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/purxiz/poe_autosplitter/main/poe.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by purxiz</Description>
+        <Website>https://www.speedrun.com/poe</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Homecoming: City of Heroes</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Add a new autosplitter for path of exile, one already exists but hasn't been updated in over a year, and is missing some routing. I will continue to update my script with new routes. For the time being it is following the most common speedrun routing for act 10 all labs and skill points.

I am not sure how to add my splits file into this so the splits can be auto-generated, but I'd like that to happen before this pull request is accepted, since the splitter is designed to work with a particular route.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ X ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ X ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ X ] The Auto Splitter has an open source license that allows anyone to fork and host it.
