### PR TITLE
Revert "Add Roboquest to LiveSplit.AutoSplitters.xml"

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15000,15 +15000,4 @@
         <Type>Script</Type>
         <Description>Load Remover for Sleeping Dogs and Sleeping Dogs: Definitive Edition. Made by Plasma</Description>
     </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Roboquest</Game>
-        </Games>
-        <URLs>
-            <URL>https://github.com/Gelmo/LiveSplit.Roboquest/raw/roboquest/Components/LiveSplit.Roboquest.dll</URL>
-        </URLs>
-        <Type>Component</Type>
-        <Description>AutoSplit, speed graph, and more. (By Gelmo)</Description>
-        <Website>https://github.com/Gelmo/LiveSplit.Roboquest</Website>
-    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Reverts LiveSplit/LiveSplit.AutoSplitters#809

This component requires the ability to add to LiveSplit's UI via the Layout menu. Unfortunately, that currently is (seemingly) not possible for components that are activated via the Splits menu.