### PR TITLE
Added ZrT Trackmania Cup and removed TM2020

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5593,6 +5593,7 @@
             <Game>StarTrack² Stadium</Game>
             <Game>StarTrack² Valley</Game>
             <Game>TrackMania One - Alpine</Game>
+            <Game>ZrT Trackmania Cup</Game>
         <Game>TrackMania² Canyon : Platform</Game>
         </Games>
         <URLs>
@@ -11313,19 +11314,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting and autostart available (by JohnStephenEvil)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Trackmania</Game>
-            <Game>Trackmania Category Extensions</Game>
-            <Game>Trackmania Club Campaigns</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Voxelse/ASLScripts/master/Livesplit.Trackmania/Livesplit.Trackmania.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Start/Split and Game Time (by Voxelse)</Description>
-        <Website>https://github.com/Voxelse/ASLScripts/tree/master/Livesplit.Trackmania</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Added ZrT Trackmania Cup to the script for Maniaplanet games and removed the Trackmania 2020 entry because the old script is broken and has been replaced by an ingame plugin that connects to Livesplit with the Server component.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
