### PR TITLE
Updated script description for ZrT Trackmania Cup

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5604,14 +5604,23 @@
             <Game>StarTrack² Stadium</Game>
             <Game>StarTrack² Valley</Game>
             <Game>TrackMania One - Alpine</Game>
-            <Game>ZrT Trackmania Cup</Game>
-        <Game>TrackMania² Canyon : Platform</Game>
+            <Game>TrackMania² Canyon : Platform</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Rastats/Maniaplanet/main/TM2-Autosplitter-IGT%20(by%20Malakat).asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>IGT timer and auto splitting options are available. (By Malakat)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>ZrT Trackmania Cup</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Rastats/Maniaplanet/main/TM2-Autosplitter-IGT%20(by%20Malakat).asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>IGT timer and auto splitting options are available only for TM² Stadium categories. (By Malakat)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
The script is only working for the TM² Stadium categories, there is an ingame plugin for the TM 2020 categories.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
