### PR TITLE
Add Death's Door Category Extensions

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13351,6 +13351,7 @@
         <Games>
             <Game>Death's Door</Game>
             <Game>Deaths Door</Game>
+            <Game>Death's Door Category Extensions</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Voxelse/LiveSplit.DeathsDoor/main/Components/LiveSplit.DeathsDoor.dll</URL>


### PR DESCRIPTION
Death's Door recently got a Category Extensions board. Adding entry to use the existing Death's Door autosplitter.

https://www.speedrun.com/ddmemes


If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.