### PR TITLE
Add Cold Steel 4 autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8361,7 +8361,7 @@
             <Game>The Legend of Heroes: Trails of Cold Steel II</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/AcridStingray3/CS2-Load-Remover/master/cs2.asl</URL>
+            <URL>https://raw.githubusercontent.com/BasedJellyfish11/CS2-Load-Remover/master/cs2.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Load remover / autosplitter available. (By AcridStingray3)</Description>
@@ -8372,18 +8372,30 @@
             <Game>The Legend of Heroes: Trails of Cold Steel 3</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/AcridStingray3/Livesplit.CS3/master/Livesplit.CS3/Components/Livesplit.CS3.dll</URL>
+            <URL>https://raw.githubusercontent.com/BasedJellyfish11/Livesplit.CS3/master/Livesplit.CS3/Components/Livesplit.CS3.dll</URL>
         </URLs>
         <Type>Component</Type>
-        <Description>Auto Splitting / Load Removing available. (By @AcridStingray3#1637)</Description>
-        <Website>https://github.com/AcridStingray3/Livesplit.CS3</Website>
+        <Description>Auto Splitting / Load Removing available. (By @AcridStingray3#5656)</Description>
+        <Website>https://github.com/BasedJellyfish11/Livesplit.CS3</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>The Legend of Heroes: Trails of Cold Steel IV</Game>
+            <Game>The Legend of Heroes: Trails of Cold Steel 4</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/BasedJellyfish11/Livesplit.CS4/master/Livesplit.CS4/Components/Livesplit.CS4.dll</URL>
+        </URLs>
+        <Type>Component</Type>
+        <Description>Auto Splitting / Load Removing available. (By @AcridStingray3#5656)</Description>
+        <Website>https://github.com/BasedJellyfish11/Livesplit.CS4</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>The Legend of Heroes: Trails of Cold Steel</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/AcridStingray3/CS1-Load-Remover/master/cs1.asl</URL>
+            <URL>https://raw.githubusercontent.com/BasedJellyfish11/CS1-Load-Remover/master/cs1.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Load remover / autosplitter available. (By AcridStingray3)</Description>
@@ -8393,7 +8405,7 @@
             <Game>Eroico</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/AcridStingray3/Eroico-autosplitter/master/eroico.asl</URL>
+            <URL>https://raw.githubusercontent.com/BasedJellyfish11/Eroico-autosplitter/master/eroico.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting, resetting and timer auto start available. (By AcridStingray3)</Description>
@@ -8404,21 +8416,10 @@
             <Game>DERU: The Art of Cooperation</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/AcridStingray3/DERU-autosplitter/master/DERU.asl</URL>
+            <URL>https://raw.githubusercontent.com/BasedJellyfish11/DERU-autosplitter/master/DERU.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting available. (By AcridStingray3)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Ibb and Obb</Game>
-            <Game>Ibb &amp; Obb</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/AcridStingray3/IbbObb-autosplitter/master/IbbObb.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter available. (By @AcridStingray3#1637 , doesn't end the timer)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Also reroutes my old autosplitters to my new username and removes the useless Ibb and Obb autosplitter

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
