### PR TITLE
Update Super Mario Bros. autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11892,11 +11892,11 @@
             <Game>Super Mario Bros.</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/g2ffi/SMBAutoSplitter/master/SuperMarioBros.asl</URL>
+            <URL>https://raw.githubusercontent.com/periwinkle9/smb-autosplitter/main/SuperMarioBros.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter for Nestopia v1.40 (By Giffi)</Description>
-        <Website>https://github.com/g2ffi/SMBAutoSplitter/</Website>
+        <Description>(NES) SMB1 autosplitter for various emulators and categories (by periwinkle)</Description>
+        <Website>https://github.com/periwinkle9/smb-autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.

I have received permission from the author to replace the existing autosplitter, as they are no longer interested in maintaining it.
