### PR TITLE
New Load Remover for Far Cry New Dawn patch 1.0.7

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8946,10 +8946,10 @@
             <Game>FC:ND</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/AlexYeahNot/asl-scripts/master/FCNDLR.asl</URL>
+            <URL>https://raw.githubusercontent.com/Binslev/FCNDLR/main/FCNDLR.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>LoadRemover is available (by AlexYeahNot )</Description>
+        <Description>LoadRemover is available (by ChiefSupreme, credit to AlexYeahNot)</Description>
         <Website>https://discord.gg/D7vJsC</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
New patch broke the old load remover, so ChiefSupreme made a new one. I am just putting it into LiveSplit for him. He used the same technique I used for Far Cry 5, and which AlexYeahNot uses for all his Far Cry load removers. I have notified Alex that I am replacing his outdated Load Remover, through our Cry Running Discord :)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
