### PR TITLE
Correct Vex 3 description

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15657,6 +15657,6 @@
             <URL>https://raw.githubusercontent.com/NoobTracker/vex-3-autosplitter/main/vex-3.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter for the Any% category, by NoobTracker</Description>
+        <Description>Autosplitter and IGT for the Any% category, by NoobTracker. For the .exe version. </Description>
     </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
The autosplitter now has an IGT feature, however, this IGT just uses a frame counter to account for lag, instead of being based on the (totally broken, 10% too slow, completely unused) actual IGT. Is that too misleading? I've asked on the Discord channel and I was told that this is an acceptable way to use the gameTime feature ...