### PR TITLE
Add new RE2 autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13505,14 +13505,21 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Biohazard 2</Game>
             <Game>Resident Evil 2</Game>
+            <Game>BH2</Game>
+            <Game>RE2</Game>
+            <Game>Resident Evil 2 1998</Game>
+            <Game>Resident Evil 2 (1998)</Game>
+            <Game>RE2 1998</Game>
+            <Game>RE2 (1998)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/CarcinogenSDA/re2-classic-autosplitter/main/re2_autosplitter_all_doors.asl</URL>
+            <URL>https://raw.githubusercontent.com/deserteagle417/RE2-Autosplitter/main/RE2aio.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>All Doors Autosplitter for use with Sourcenext 1.10 and RE2 Classic REbirth (by CarcinogenSDA)</Description>
-        <Website>https://github.com/CarcinogenSDA/re2-classic-autosplitter</Website>
+        <Description>Door and Item autosplits for all scenarios and side games. Compatible with all versions of the game. See Website for more detail. (by deserteagle417)</Description>
+        <Website>https://github.com/deserteagle417/RE2-Autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Permission obtained by CarcinogenSDA to overwrite the existing autosplitter.