### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
-    <Autosplitter>
-            <Games>
+    <AutoSplitter>
+        <Games>
             <Game>Deadly Premonition: Director's Cut</Game>
             <Game>Deadly Premonition</Game>
         </Games>
@@ -10,7 +10,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Load Remover and Autostart by streetbackguy</Description>
-    </Autosplitter>
+    </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Kingdom Hearts II Final Mix</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+    <Autosplitter>
+            <Games>
+            <Game>Deadly Premonition: Director's Cut</Game>
+            <Game>Deadly Premonition</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/main/Livesplit.DeadlyPremonition.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Remover and Autostart by streetbackguy</Description>
+    </Autosplitter>
     <AutoSplitter>
         <Games>
             <Game>Kingdom Hearts II Final Mix</Game>


### PR DESCRIPTION
Seems the last commit was missing the <autosplitter> tag, so rectified this time.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
