### PR TITLE
add Pathfinder: Kingmaker auto splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15035,6 +15035,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Pathfinder: Kingmaker</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/just-ero/asl/raw/main/Pathfinder%20%E2%80%93%20Kingmaker/Pathfinder_Kingmaker.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/Components/LiveSplit.ASLHelper.bin</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Removes loads. (by Ero)</Description>
+        <Website>https://github.com/just-ero/asl/tree/main/Pathfinder%20%E2%80%93%20Kingmaker</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Pathfinder: Wrath of the Righteous</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
