### PR TITLE
Add Zapling Bygone autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15834,4 +15834,14 @@
         <Type>Script</Type>
         <Description>LiveSplit connection for Gothic 1/2 Timer mod available</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Zapling Bygone</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ori-sky/asl/main/zapling-bygone.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto-starts, splits when the run is over (by Ori Sky)</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
This patch adds the autosplitter for Zapling Bygone to the autosplitters XML file.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
