### PR TITLE
Made soulsplitter the default plugin for DS1

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4029,22 +4029,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Dark Souls</Game>
-            <Game>Dark Souls 1</Game>
-            <Game>Dark Souls 1: Prepare to Die Edition</Game>
-            <Game>Dark Souls: Prepare to Die Edition</Game>
-            <Game>Dark Souls Remastered</Game>
-            <Game>Dark Souls: Remastered</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/CapitaineToinon/LiveSplit.DarkSoulsIGT/master/LiveSplit.DarkSoulsIGT/Components/LiveSplit.DarkSoulsIGT.dll</URL>
-        </URLs>
-        <Type>Component</Type>
-        <Description>Game Time is available. (By CapitaineToinon)</Description>
-        <Website>https://github.com/CapitaineToinon/LiveSplit.DarkSoulsIGT</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Dark Souls 2</Game>
             <Game>Dark Souls II</Game>
             <Game>Dark Souls 2: SotFS</Game>
@@ -14672,6 +14656,12 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Dark Souls</Game>
+            <Game>Dark Souls 1</Game>
+            <Game>Dark Souls 1: Prepare to Die Edition</Game>
+            <Game>Dark Souls: Prepare to Die Edition</Game>
+            <Game>Dark Souls Remastered</Game>
+            <Game>Dark Souls: Remastered</Game>
             <Game>Dark Souls III</Game>
             <Game>Dark Souls 3</Game>
             <Game>Sekiro</Game>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.