### PR TITLE
Added support for Cult of the Lamb including Demo version.

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -205,14 +205,16 @@
             <Game>Cult of the Lamb Demo</Game>
             <Game>COTL Demo</Game>
             <Game>COTLD</Game>
+            <Game>Cult of the Lamb</Game>
+            <Game>COTL</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/MelloYourFello/Autosplitters/raw/main/COTL_DEMO.asl</URL>
+            <URL>https://raw.githubusercontent.com/glcoder/asl/main/Cult%20Of%20The%20Lamb.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/main/Components/LiveSplit.ASLHelper.bin</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter for the Demo of Cult of the Lamb (Made by MelloYourFello)</Description>
-        <Website>https://www.speedrun.com/cotl_demo</Website>
+        <Description>Autosplitter and load remover for Cult of the Lamb.</Description>
+        <Website>https://github.com/glcoder/asl/blob/main/Cult%20Of%20The%20Lamb.asl</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Full support for Cult of the Lamb, replacing original ASL by @MelloYourFello as I contacted him and we decided to keep only this one.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
