### PR TITLE
Add Plants vs. Zombies Category Extensions

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11280,6 +11280,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Plants vs. Zombies Category Extensions</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ymblcza/ASL-Scripts/master/PlantsVsZombies.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>For pvz original and Steam version.</Description>
+        <Website>https://discord.gg/ss5uTqE</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Zed</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
This change adds the existing Plants vs. Zombies autosplitter to the Plants vs. Zombies Category Extensions page.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x ] The Auto Splitter has an open source license that allows anyone to fork and host it.
