### PR TITLE
Update MindSeize autosplitter URL

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11314,7 +11314,7 @@
             <Game>MindSeize</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/shockkolate/mindseize-autosplitter/master/mindseize.asl</URL>
+            <URL>https://raw.githubusercontent.com/ori-sky/mindseize-autosplitter/master/mindseize.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto-splitting and auto-start are available (by Shockk)</Description>


### PR DESCRIPTION
This patch updates the MindSeize autosplitter URL to point to the new location of the repository. Although the URL currently works as intended, there's no way of knowing if this will change in the future if my old username is claimed by a different user at some point. As proof that this is still the same repository, the redirect to the new URL can be seen by attempting to navigate to https://github.com/shockkolate/mindseize-autosplitter and seeing that it redirects to https://github.com/ori-sky/mindseize-autosplitter .

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
