### PR TITLE
Add Night at the Gates of Hell script

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Night at the Gates of Hell</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Night%20at%20the%20Gates%20Of%20Hell/natgoh.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load removing is available. (By diggity)</Description>
+        <Website>https://www.speedrun.com/night_at_the_gates_of_hell</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Contra Hard Corps</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Note that while this is a unity game, it is mono v3 x86 and thus doesn't use the ASL helper library