### PR TITLE
Replace Cuphead Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7105,13 +7105,11 @@
             <Game>Cuphead Category Extensions</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/just-ero/asl/raw/main/Cuphead/Cuphead.asl</URL>
-            <URL>https://github.com/just-ero/asl/raw/main/Cuphead/Cuphead.Splits.xml</URL>
-            <URL>https://github.com/just-ero/asl-help/raw/main/lib/LiveSplit.ASLHelper.bin</URL>
+            <URL>https://raw.githubusercontent.com/ShootMe/LiveSplit.Cuphead/master/Components/LiveSplit.Cuphead.dll</URL>
         </URLs>
-        <Type>Script</Type>
-        <Description>Starts automatically. Splits are available in the settings. Removes loads. (temp fix by Ero)</Description>
-        <Website>https://github.com/just-ero/asl/tree/main/Cuphead</Website>
+        <Type>Component</Type>
+        <Description>Autosplitting and Load Removal is available. (By DevilSquirrel)</Description>
+        <Website>https://github.com/ShootMe/LiveSplit.Cuphead</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
The asl autosplitter that is currently in this document was a temporary solution for Cuphead's DLC update, which broke the old component autosplitter that couldn't be fixed at the time. The component has since been updated, and seems to be more reliable and preferred by the community.

---------

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
