### PR TITLE
Autosplitter for Desperados III

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16274,4 +16274,14 @@
         <Type>Script</Type>
         <Description>Auto starting, splitting and load removal are available. (By hdc0)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Desperados III</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/smorrrs/Desperados-III-Resources/main/desperados_iii.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start, split, and load removal by smorrs</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
This game brings you to the level selection screen upon completing a level, but levels should be completed in order in full game runs so the splitter has logic to account for this. Also, the game's level name string contains several components including difficulty setting, so the splitter has parsing to grab just the relevant piece.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x ] The Auto Splitter has an open source license that allows anyone to fork and host it.
