### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16310,7 +16310,7 @@
             <Game>Organism</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/danielditlev/LiveSplit.AutoSplitters/blob/main/C64_organism.asl</URL>
+            <URL>https://raw.githubusercontent.com/danielditlev/LiveSplit.AutoSplitters/main/C64_organism.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>ASL script for the 2018 C64 game 'Organism'. Meant for use with Vice 3.6.1</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16305,4 +16305,14 @@
         <Type>Script</Type>
         <Description>Starting and splitting by Andet, credit to Ero for asl-help</Description>
     </AutoSplitter>
-</AutoSplitters>
+    <AutoSplitter>
+        <Games>
+            <Game>Organism</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/danielditlev/LiveSplit.AutoSplitters/blob/main/C64_organism.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>ASL script for the 2018 C64 game 'Organism'. Meant for use with Vice 3.6.1</Description>
+    </AutoSplitter>
+  </AutoSplitters>


### PR DESCRIPTION
Added support for the C64 game 'Organism'. Memory offsets are based on Vice 3.6.1.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
