### PR TITLE
Added Hue Category Extensions

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7545,8 +7545,18 @@
             <URL>https://raw.githubusercontent.com/Modiseus/Hue-Auto-Splitter/master/Hue.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Start and auto-splitting are available. (By Modiseus)</Description>
+        <Description>Auto starting, splitting and load removal are available. (By Modiseus, jboardman367 and LukeSaward1)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Hue Category Extensions</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Modiseus/Hue-Auto-Splitter/master/Hue.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto starting, splitting and load removal are available. (By Modiseus, jboardman367 and LukeSaward1)</Description>
+    </AutoSplitter>  
     <AutoSplitter>
         <Games>
             <Game>Croc 2</Game>


### PR DESCRIPTION
This also updates the description for the base game.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
