### PR TITLE
Add Last Battle / Hokuto no Ken auto splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16559,4 +16559,15 @@
         <Description>Auto start/split and load removal available. (By Banz)</Description>
         <Website>https://github.com/Banzkux/autosplitters/blob/main/freedom-fighters/README.md</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Last Battle/Hokuto no Ken</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/dread-pirate-johnny-spaceboots/last-battle-autosplitter/master/LastBattle.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start/split/reset. (By Johnny Spaceboots)</Description>
+        <Website>https://github.com/dread-pirate-johnny-spaceboots/last-battle-autosplitter</Website>
+    </AutoSplitter>
   </AutoSplitters>


### PR DESCRIPTION
Adding an auto splitter for Last Battle / Hokuto no Ken for the Genesis/Mega Drive

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
