### PR TITLE
Fix description of gorge autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19,7 +19,7 @@
             <URL>https://raw.githubusercontent.com/Fibes1/gorge-autosplitter/main/gorge-autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter &amp; load remover (by Fibes)</Description>
+        <Description>Autosplitter and load remover (by Fibes)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
The ampersand doesn't show up in livesplit

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
