### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16806,4 +16806,14 @@
         <Type>Script</Type>
         <Description>Autosplitter with load removal by Andet</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Crisis Core: Final Fantasy VII - Reunion</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/desa35/CCFF7R-Loadremover/master/CCFF7R.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Loadremover with automatic Timer Start by desa.</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Adds Loadremover to Crisis Core: Final Fantasy VII - Reunion

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
