### PR TITLE
Fix Sinner97 game name

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16514,7 +16514,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Sinner97</Game>
+            <Game>Sinner 97</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/edunad/sinner-97-autosplit/master/sinner97.asl</URL>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

I missed a space on the 97, my bad 😥 and speedrun.com was created with it