### PR TITLE
Added ASL for the new Dead Space + renamed MattMatts ASL to reflect g…

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+<AutoSplitter>
+        <Games>
+            <Game>Dead Space</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.DeadSpaceRemake/main/DeadSpaceRemake.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Removal is available (by Meta)</Description>
+    </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Barbie and the Magic of Pegasus (PC)</Game>
@@ -7629,9 +7639,9 @@
         <Description>Auto Start and Split are available. Split points chosen by user. More may be added by request. (By Roosta)</Description>
         <Website>https://github.com/blakehartley/LRFF13_autosplitter</Website>
     </AutoSplitter>
-    <AutoSplitter>
+   <AutoSplitter>
         <Games>
-            <Game>Dead Space</Game>
+            <Game>Dead Space (2008)</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Mattmatt10111/asl-scripts/master/deadspace.asl</URL>


### PR DESCRIPTION
…ames new name

The developers changed the name of the old Dead Space, and so did the SRC leaderboard. So I've added the new Dead Space (remake) ASL and just renamed MattMatts old Dead Space (original) to reflect the names appropriately so they can be selected in LiveSplit. No changes to MattMatts repo were made

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
