### PR TITLE
Lingo Custom Maps autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -17230,6 +17230,7 @@
     <AutoSplitter>
         <Games>
             <Game>Lingo</Game>
+            <Game>Lingo Custom Maps</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/hatkirby/autosplitters/main/Lingo.asl</URL>


### PR DESCRIPTION
Lingo autosplitter works for Lingo Custom Maps as well

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
