### PR TITLE
Added Splinter Cell: Chaos Theory AutoSplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3713,11 +3713,6 @@
             <Game>Unreal Return to Na Pali</Game>
             <Game>Return to Na Pali</Game>
             <Game>Unreal Mission Pack: Return to Na Pali</Game>
-            <Game>Splinter Cell 3</Game>
-            <Game>Splinter Cell: Chaos Theory</Game>
-            <Game>Splinter Cell Chaos Theory</Game>
-            <Game>Tom Clancy's Splinter Cell: Chaos Theory</Game>
-            <Game>Tom Clancy's Splinter Cell Chaos Theory</Game>
             <Game>XCOM Enforcer</Game>
             <Game>X-COM Enforcer</Game>
             <Game>XCOM: Enforcer</Game>
@@ -16333,7 +16328,11 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Splinter Cell 3</Game>
+            <Game>Splinter Cell: Chaos Theory</Game>
+            <Game>Splinter Cell Chaos Theory</Game>
             <Game>Tom Clancy's Splinter Cell: Chaos Theory</Game>
+            <Game>Tom Clancy's Splinter Cell Chaos Theory</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/DistProg/SCCTAutoSplitter/main/SCCT_AutoSplitter.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16333,6 +16333,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Tom Clancy's Splinter Cell: Chaos Theory</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/DistProg/SCCTAutoSplitter/main/SCCT_AutoSplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load removal available (by Distro)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Cry of Fear</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Added SCCT autosplitter with load removal functionality.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
