### PR TITLE
Updated Star Wars Force Unleashed II

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -179,7 +179,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Star Wars: The Force Unleashed 2</Game>
+            <Game>Star Wars: The Force Unleashed II</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/main/LiveSplit.SWTFU2.asl</URL>
@@ -5099,17 +5099,6 @@
         <Type>Component</Type>
         <Description>Auto Splitting is available. (By sashavol/garebear)</Description>
     </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Star Wars: The Force Unleashed II</Game>
-            <Game>SWTFU II</Game>
-            <Game>SWTFU 2</Game>
-        </Games>
-        <URLs>
-            <URL>https://gist.githubusercontent.com/Zuzurr/da2e16ed6eb561a7baca69a97d20a4fe/raw/043d98f72ee481a75be177050f76fdab7732f1e1/SWFTU2loads.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Load Removal is available. (By Zuzur)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Removed old version by Zuzur as their ASL didn't exist anymore, and corrected game name for the most up to date version by Scales.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
