### PR TITLE
Updating Star Wars Battlefront II .asl

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7457,7 +7457,7 @@
             <Game>Star Wars Battlefront II</Game>
         </Games>
         <URLs>
-            <URL>https://gist.githubusercontent.com/Lako3000/3098368ac04c1f50d3e9e7b52c843088/raw/a9a84a3131d197667d83ebbf40dc195ede524110/gistfile1.txt</URL>
+            <URL>https://raw.githubusercontent.com/9Tpercentmon/swbf2_loadremover/main/swbf2_loadremover_v2.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Load Removal is available. (By lako3000)</Description>


### PR DESCRIPTION
Back in 2018, there was an update on the game that broke the previous load remover. This new one was also made by Lako, so I'm keeping the credits to him on the <Description>
Since he seems to be gone, I'm updating it myself. If it helps due to the "permission from the author" rule, I'm also a mod in the [swbf2 speedrun leaderboards](speedrun.com/swbf2)

Edit: it's the same file uploaded by him on the [resources page](https://www.speedrun.com/swbf2/resources) - (Loads Remover Steam Version 12/01/2018 (2.0))

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
