### PR TITLE
Adding other names for Star Wars Battlefront II

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7455,6 +7455,9 @@
     <AutoSplitter>
         <Games>
             <Game>Star Wars Battlefront II</Game>
+            <Game>Star Wars Battlefront II (2005)</Game>
+            <Game>Star Wars: Battlefront II</Game>
+            <Game>Star Wars: Battlefront II (2005)</game>
         </Games>
         <URLs>
             <URL>https://gist.githubusercontent.com/Lako3000/3098368ac04c1f50d3e9e7b52c843088/raw/a9a84a3131d197667d83ebbf40dc195ede524110/gistfile1.txt</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7457,7 +7457,7 @@
             <Game>Star Wars Battlefront II</Game>
             <Game>Star Wars Battlefront II (2005)</Game>
             <Game>Star Wars: Battlefront II</Game>
-            <Game>Star Wars: Battlefront II (2005)</game>
+            <Game>Star Wars: Battlefront II (2005)</Game>
         </Games>
         <URLs>
             <URL>https://gist.githubusercontent.com/Lako3000/3098368ac04c1f50d3e9e7b52c843088/raw/a9a84a3131d197667d83ebbf40dc195ede524110/gistfile1.txt</URL>


### PR DESCRIPTION
The original .xml has the 2005 Star Wars Battlefront II listed without a colon, but the game is actually listed with a colon (so livesplit can't find the .asl).
I also added a few other alias just in case

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
