### PR TITLE
Added sonic frontiers autosplitter to catexes

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8645,6 +8645,7 @@
     <AutoSplitter>
         <Games>
             <Game>Sonic Frontiers</Game>
+	    <Game>Sonic Frontiers Category Extensions</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/SonicSpeedrunning/LiveSplit.SonicFrontiers/main/Components/LiveSplit.SonicFrontiers.dll</URL>


### PR DESCRIPTION
extra game for the same autosplitter

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ X] The Auto Splitter has an open source license that allows anyone to fork and host it.
