### PR TITLE
Updated Sonic Mania autosplitter to .wasm

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9592,10 +9592,11 @@
             <Game>Sonic Mania</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/SonicSpeedrunning/LiveSplit.SonicMania/main/LiveSplit.SonicMania.asl</URL>
+            <URL>https://github.com/SonicSpeedrunning/LiveSplit.SonicMania/releases/download/latest/livesplit_sonicmania.wasm</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto splitting/start/reset available. Splits at the end of each act. (by Jujstme and Claris)</Description>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Auto splitting/start/reset available. Configurable splits for each act. (by Jujstme and Claris)</Description>
         <Website>https://github.com/SonicSpeedrunning/LiveSplit.SonicMania</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
Another game using the new autosplitting runtime.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
