### PR TITLE
Adds Tubbyland: 2003

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -17789,4 +17789,14 @@
         <Type>Script</Type>
         <Description>Automated Starting, Spliting and Load Removing by derric_young</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Tubbyland: 2003</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/derric-young/Tubbyland-2003-Autosplitter/main/2003.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autonomus Start, Split, Reset and load Removing by Derric</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Tubbyland 2003 is a Sadly Cancelled Videogame Developed by ThereNoSteak. its was not finished and the build we have does not contain the weird 5am sequence so we have what we have. and yes. the autosplitter is built on that

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
