### PR TITLE
Updated Sonic Colors Ultimate to .wasm

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2958,7 +2958,6 @@
             <URL>https://raw.githubusercontent.com/SonicSpeedrunning/LiveSplit.SonicColors/master/Components/LiveSplit.SonicColors.dll</URL>
         </URLs>
         <Type>Component</Type>
-        <ScriptType>AutoSplittingRuntime</ScriptType>
         <Description>Autosplitting and In-Game Timer are available (by Jujstme)</Description>
         <Website>https://discord.gg/XRsRwRU</Website>
     </AutoSplitter>
@@ -2971,6 +2970,7 @@
             <URL>https://github.com/SonicSpeedrunning/LiveSplit.SonicColorsUltimate/releases/download/latest/livesplit_soniccolorsultimate.wasm</URL>
         </URLs>
         <Type>Script</Type>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
         <Description>Autosplitting and In-Game Timer are available (by Jujstme)</Description>
         <Website>https://discord.gg/XRsRwRU</Website>
     </AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2953,14 +2953,25 @@
         <Games>
             <Game>Sonic Colors</Game>
             <Game>Sonic Colours</Game>
-            <Game>Sonic Colors: Ultimate</Game>
-            <Game>Sonic Colours: Ultimate</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/SonicSpeedrunning/LiveSplit.SonicColors/master/Components/LiveSplit.SonicColors.dll</URL>
         </URLs>
         <Type>Component</Type>
-        <Description>Autosplitting and In-Game Timer are available. Supports both Sonic Colors and Sonic Colors: Ultimate (by Jujstme)</Description>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Autosplitting and In-Game Timer are available (by Jujstme)</Description>
+        <Website>https://discord.gg/XRsRwRU</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Sonic Colors: Ultimate</Game>
+            <Game>Sonic Colours: Ultimate</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/SonicSpeedrunning/LiveSplit.SonicColorsUltimate/releases/download/latest/livesplit_soniccolorsultimate.wasm</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and In-Game Timer are available (by Jujstme)</Description>
         <Website>https://discord.gg/XRsRwRU</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
Sonic Colors (the base version, emulated via Dolphin) has been separated in order to keep using the .dll component, which allows emu supports via emu-help code

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
