### PR TITLE
Adds Post-Shift 2 Autosplitter and Updates the Description of The Tub…

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -17830,7 +17830,7 @@
             <URL>https://raw.githubusercontent.com/derric-young/TTLAAutosplitter/main/The%20Tubbyland%20Archives%20Autosplitting%20Systems.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Automated Starting, Spliting and Load Removing by derric_young</Description>
+        <Description>Automated Starting, Spliting and Load Remover (by derric_young)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -17840,7 +17840,7 @@
             <URL>https://raw.githubusercontent.com/derric-young/Tubbyland-2003-Autosplitter/main/2003.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autonomus Start, Split, Reset and load Removing by Derric</Description>
+        <Description>Autonomus Start, Split, Reset and load Remover (by Derric)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -17861,5 +17861,15 @@
         </URLs>
         <Type>Script</Type>
         <Description>Auto Splitting and In Game Time are available. (By TheDementedSalad)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Post-Shift 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/derric-young/Post-Shift-2-Autosplitter/main/p-s2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter for Both Part A and Part B (by The Real Derric Young)</Description>
     </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
…byland Archives's autosplitter and Tubbyland: 2003's Autosplitters (both made by me)

the autosplitter that solves the 2 exe problem. may be useful for ttla when act 2 comes out. would make more for other games

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
