### PR TITLE
Added autosplitter for The Murder of Sonic The Hedgehog

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -264,6 +264,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>The Murder of Sonic the Hedgehog</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/SonicSpeedrunning/LiveSplit.SonicMurder/releases/download/latest/livesplit_murderofsonic.wasm</URL>
+        </URLs>
+        <Type>Script</Type>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Autosplitter with customizable options (by Jujstme)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Hogwarts Legacy</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Yet another autosplitter using the new autosplitting runtime...

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
