### PR TITLE
adds Live A Live (2022)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18106,4 +18106,15 @@
         <Description>Autosplitter, auto-reset, death count, and game time (By Gaphodil)</Description>
         <Website>https://github.com/Gaphodil/autosplitters/tree/main/bonk-autosplitter</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Live A Live (2022)</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/Eein/live-a-live-autosplitter-wasm/releases/latest/download/live_a_live_autosplitter_wasm.wasm</URL> </URLs>
+        <Type>Script</Type>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Auto Splitting and Game Time are available (by SuperFamicom)</Description>
+        <Website>https://github.com/Eein/live-a-live-autosplitter-wasm</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

The name "Live a Live (2022)" lines up with speedrun description, not sure if this will cause issues. 