### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -12318,7 +12318,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Jurassic Park SNES</Game>
+            <Game>Jurassic Park (SNES)</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Halderim/autosplitter/main/LiveSplit.JurassicParkSNES.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -12318,6 +12318,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Jurassic Park SNES</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Halderim/autosplitter/main/LiveSplit.JurassicParkSNES.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description> Autosplitting, timer start and reset timer available (by Halderim)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Jurassic Park: Trespasser</Game>
             <Game>Trespasser</Game>
             <Game>Trespasser: Jurassic Park</Game>


### PR DESCRIPTION
Added Autosplitter for the game Jurassic Park for SNES to the XML

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x ] The Auto Splitter has an open source license that allows anyone to fork and host it.
