### PR TITLE
Add Splinter Cell Double Agent Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16794,6 +16794,20 @@
         <Description>Load removal available (by Distro)</Description>
     </AutoSplitter>
     <AutoSplitter>
+	<Games>
+            <Game>Splinter Cell 4</Game>
+            <Game>Splinter Cell: Double Agent</Game>
+            <Game>Splinter Cell Double Agent</Game>
+            <Game>Tom Clancy's Splinter Cell: Double Agent</Game>
+            <Game>Tom Clancy's Splinter Cell Double Agent</Game>
+	</Games>
+	<URLs>
+	    <URL>https://raw.githubusercontent.com/Marius150PL/SCDA-AutoSplitter/main/SCDA-AutoSplitter.asl</URL>
+	</URLs>
+	<Type>Script</Type>
+	<Description>Autostart/split (remembers visited levels until reset) and load removal (by Marius150PL &amp; Distro)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
         <Games>
             <Game>Splinter Cell 6</Game>
             <Game>Splinter Cell: Blacklist</Game>


### PR DESCRIPTION
Added Splinter Cell: Double Agent Autosplitter.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
