### PR TITLE
Add Feeding Frenzy 2: Shipwreck Showdown

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18388,6 +18388,18 @@
     </AutoSplitter>
     <AutoSplitter>
 	<Games>
+	    <Game>Feeding Frenzy 2: Shipwreck Showdown</Game>
+	    <Game>Feeding Frenzy 2</Game>
+	</Games>
+	<URLs>
+	    <URL>https://raw.githubusercontent.com/Xh3o1vn/FeedingFrenzy2_Autosplitter/main/FeedingFrenzy2.asl</URL>
+	</URLs>
+	<Type>Script</Type>
+	<Description>AutoSplitter for Feeding Frenzy 2 (By Xh3o1vn and plAer2)</Description>
+	<Website>https://github.com/Xh3o1vn/FeedingFrenzy2_Autosplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+	<Games>
 	    <Game>Transformers: War for Cybertron</Game>
 	</Games>
 	<URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- * [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- * [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- * [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
