### PR TITLE
Add Shrek 2 (PC) support via .asl

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4666,14 +4666,16 @@
     <AutoSplitter>
         <Games>
             <Game>Shrek 2</Game>
+            <Game>Shrek 2 PC</Game>
             <Game>Shrek 2 (PC)</Game>
+            <Game>Shrek 2: The Game</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/Master-64/Shrek2-LiveSplit/master/Shrek2-LiveSplit/Components/Shrek2-LiveSplit.dll</URL>
+            <URL>https://raw.githubusercontent.com/Master-64/Shrek2-LiveSplit-ASL/main/Source/Shrek_2_PC.asl</URL>
         </URLs>
         <Type>Component</Type>
-        <Description>Auto Splitting &amp; Load Removal is available. (By KevinJPetersen, Master_64 &amp; Dalet)</Description>
-        <Website>https://github.com/Master-64/Shrek2-LiveSplit/blob/master/README.md</Website>
+        <Description>Autosplitting and Load Removal is available. (By Master_64)</Description>
+        <Website>https://github.com/Master-64/Shrek2-LiveSplit-ASL/blob/main/README.md</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4673,7 +4673,7 @@
         <URLs>
             <URL>https://raw.githubusercontent.com/Master-64/Shrek2-LiveSplit-ASL/main/Source/Shrek_2_PC.asl</URL>
         </URLs>
-        <Type>Component</Type>
+        <Type>Script</Type>
         <Description>Autosplitting and Load Removal is available. (By Master_64)</Description>
         <Website>https://github.com/Master-64/Shrek2-LiveSplit-ASL/blob/main/README.md</Website>
     </AutoSplitter>


### PR DESCRIPTION
Replacing the .dll version of the S2PC autosplitter with a new, more stable, .asl version of it. It's also the most up-to-date autosplitter for the game at the moment, so it would be preferred if this change was made. As I am the owner of the autosplitter that is currently listed on the .xml, I've changed the repository for it, as the scope of the autosplitting project has drastically changed recently, and the newest one I've been working on is more accurate than the old one. Thanks.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ X ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ X ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ X ] The Auto Splitter has an open source license that allows anyone to fork and host it.
