### PR TITLE
Added Dorfromantik AutoSplitter for Point Based Categories

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,16 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Dorfromantik</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Raqhael/Dorfromantik-Autosplitter/main/LiveSplit.Dorfromantik.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Simple Autosplitter for Dorfromantik Point-Based Categories. It Starts on New Game and Stops at either 2,5,10 or 25k Points based on setting. NOTE: The first tile needs to make a point to start the timer. Made by endunry</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>World of Horror</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Created a simple Autosplitter to Start/Split/Reset point based categories for the Game [Dorfromantik ](https://www.speedrun.com/de-DE/Dorfromantik)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

