### PR TITLE
Add an auto splitter for the game Mondealy

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19293,4 +19293,14 @@
         <Type>Script</Type>
         <Description>Auto Start/Split/Reset and Load Removal and IGT track are all Available (By LeonSReckon)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Mondealy</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/nkrapivin/mondealy-asl/master/mondealy.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Official autosplitter, requires --livesplit launch parameter. Splits by chapters, has auto start, reset and gameTime</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Requires the `--livesplit` launch parameter to be specified in order to use the auto splitter.

The way it works is explained in the README: https://github.com/nkrapivin/mondealy-asl

Currently the livesplit integration code is in the public "livesplit" Steam beta branch, but it is already merged in Git and will be available shortly to everyone, I am submitting this in advance.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

It is under "The Unlicense" because I am one of the developers of the game, I did the console ports and other tech-y stuff and so I really don't care what people do with it, it took me a day or so to implement.
