### PR TITLE
Updating autosplitter for Life is Strange

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14866,10 +14866,10 @@
             <Game>Life Is Strange</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/Firefox0/Life-Is-Strange/master/lis.asl</URL>
+            <URL>https://raw.githubusercontent.com/aranel616/autosplitters/main/Life%20Is%20Strange/LifeIsStrange.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter for Life Is Strange. (By PuertoLobos)</Description>
+        <Description>Autosplitter for Life Is Strange. (By Aranel616)</Description>
         <Website>https://www.speedrun.com/life_is_strange</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
The current autosplitter for Life is Strange links to a 404. This PR replaces it with a new autosplitter written from scratch.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [✔️] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [✔️] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [✔️] The Auto Splitter has an open source license that allows anyone to fork and host it.
