### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19365,6 +19365,6 @@
             <URL>https://raw.githubusercontent.com/Auddy07/ASL/master/BRC.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal is available (By Auddy & Loomeh)</Description>
+        <Description>Auto Splitting and Load Removal is available (By Auddy and Loomeh)</Description>
     </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19365,6 +19365,6 @@
             <URL>https://raw.githubusercontent.com/Auddy07/ASL/master/BRC.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal is available (By Auddy &amp; Loomeh)</Description>
+        <Description>Auto Splitting and Load Removal is available (By Auddy & Loomeh)</Description>
     </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
The "&" was not showing up in the description for the BRC timer

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X ] The Auto Splitter has an open source license that allows anyone to fork and host it.
