### PR TITLE
Change Bomb Rush Cyberfunk autosplitter location

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19362,9 +19362,9 @@
             <Game>Bomb Rush Cyberfunk</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/Auddy07/ASL/master/BRC.asl</URL>
+            <URL>https://raw.githubusercontent.com/Loomeh/BRCAutosplitter/main/BRC.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal is available (By Auddy &amp; Loomeh)</Description>
+        <Description>Auto Splitting and Load Removal is available (By Auddy and Loomeh)</Description>
     </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Autosplitter has changed to a repo on my profile as co-developer Auddy has said that he's no longer going to be developing the autosplitter. He's okay with it.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ Yes ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ Yes ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ Yes ] The Auto Splitter has an open source license that allows anyone to fork and host it.
