### PR TITLE
add Guild Wars loading screen splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -639,6 +639,20 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Guild Wars: Prophecies</Game>
+            <Game>Guild Wars: Factions</Game>
+            <Game>Guild Wars: Nightfall</Game>
+            <Game>Guild Wars: Eye of the North</Game>
+            <Game>Guild Wars: All Campaigns</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/DubbleClick/Guild-Wars-Autosplitters/main/GwLoadingScreenStop.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto stop/resume during loading screens.</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Scars Above</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
