### PR TITLE
Update SADX game name to reflect SRC changes

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3837,7 +3837,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Sonic Adventure (DX)</Game>
+            <Game>Sonic Adventure DX: Director's Cut</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Sora-yx/autosplitters/master/Sonic%20Adventure%20DX-%20Director-s%20Cut/LiveSplit.SADX.asl</URL>
@@ -5506,21 +5506,6 @@
         <Type>Script</Type>
         <Description>Load Removal and Auto Start/Reset/Split are available. (By Tenit)</Description>
         <Website>https://github.com/TitaniumBlue1/Autosplitters/blob/master/README.md</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Sonic Adventure DX</Game>
-            <Game>SADX</Game>
-            <Game>Sonic Adventure DX: Director's Cut</Game>
-            <Game>Sonic Adventure DX: Directors Cut</Game>
-            <Game>Sonic Adventure DX Director's Cut</Game>
-            <Game>Sonic Adventure DX Directors Cut</Game>
-        </Games>
-        <URLs>
-            <URL>https://dl.dropboxusercontent.com/s/phb0per4f9zyecw/sadx.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting (Beta-v1) is available. (By VeritasDL)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
The speedrun.com moderators of [Sonic Adventure DX](https://www.speedrun.com/sadx) changed the name of the game from Sonic Adventure (DX) to Sonic Adventure DX: Director's Cut.
These changes mean that LiveSplit picks up the old auto splitter that @VeritasDL published a long time ago if you enter the correct game name from SRC.
I've asked Veritas if he was okay with us replacing his old auto splitter on the list which he agreed to

![image](https://github.com/LiveSplit/LiveSplit.AutoSplitters/assets/38794835/0639c6e6-35ab-40eb-8114-82bee3cff968)

Since i'm not a mod on SADX myself, I've also asked Tethys (a SADX SRC mod) if they're okay with that and it looks like they are.

![image](https://github.com/LiveSplit/LiveSplit.AutoSplitters/assets/38794835/f541cb02-5b1c-4429-a4e8-784ff8e89a6a)

I know it's not ideal that I'm the one making this pull request but we kinda need this situation resolved quickly.
Anyway, have a nice day :)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
