### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3841,7 +3841,6 @@
     <AutoSplitter>
         <Games>
             <Game>Sonic Adventure DX: Director's Cut</Game>
-            <Game>Sonic Adventure DX: Director's Cut</Game>
             <Game>Sonic Adventure (DX)</Game>
             <Game>Sonic Adventure DX</Game>
             <Game>Sonic Adventure DX Director's Cut</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3841,13 +3841,12 @@
     <AutoSplitter>
         <Games>
             <Game>Sonic Adventure DX: Director's Cut</Game>
+            <Game>Sonic Adventure DX: Director's Cut</Game>
             <Game>Sonic Adventure (DX)</Game>
             <Game>Sonic Adventure DX</Game>
             <Game>Sonic Adventure DX Director's Cut</Game>
             <Game>SADX</Game>
             <Game>Sonic Adventure (DX): Director's Cut</Game>
-            <Game>Sonic Adventure (DX): Category Extensions</Game>
-            <Game>Sonic Adventure DX: Category Extensions</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Sora-yx/autosplitters/master/Sonic%20Adventure%20DX-%20Director-s%20Cut/LiveSplit.SADX.asl</URL>
@@ -3857,6 +3856,18 @@
         <Website>https://discord.gg/NUCatnN</Website>
     </AutoSplitter>
     <AutoSplitter>
+        <Games>
+            <Game>Sonic Adventure (DX) - Category Extensions</Game>
+            <Game>Sonic Adventure (DX): Category Extensions</Game>
+            <Game>Sonic Adventure DX: Category Extensions</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Sora-yx/autosplitters/master/Sonic%20Adventure%20DX-%20Director-s%20Cut/LiveSplit.SADXIGT.ExT.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description> Autosplitter and IGT for SADX Category Extensions (by Turtlechuck, IDGeek121, Prahaha and Sora)</Description>
+        <Website>https://discord.gg/NUCatnN</Website>
+    </AutoSplitter>
         <Games>
             <Game>Spark the Electric Jester 3</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3868,6 +3868,7 @@
         <Description> Autosplitter and IGT for SADX Category Extensions (by Turtlechuck, IDGeek121, Prahaha and Sora)</Description>
         <Website>https://discord.gg/NUCatnN</Website>
     </AutoSplitter>
+    <AutoSplitter>
         <Games>
             <Game>Spark the Electric Jester 3</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3737,17 +3737,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Sonic Adventure (DX) - Category Extensions</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Sora-yx/autosplitters/master/Sonic%20Adventure%20DX-%20Director-s%20Cut/LiveSplit.SADXIGT.ExT.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description> Autosplitter and IGT for SADX Category Extensions (by Turtlechuck, IDGeek121, Prahaha and Sora)</Description>
-        <Website>https://discord.gg/NUCatnN</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Super Gussun Oyoyo 2</Game>
         </Games>
         <URLs>
@@ -3852,6 +3841,13 @@
     <AutoSplitter>
         <Games>
             <Game>Sonic Adventure DX: Director's Cut</Game>
+            <Game>Sonic Adventure (DX)</Game>
+            <Game>Sonic Adventure DX</Game>
+            <Game>Sonic Adventure DX Director's Cut</Game>
+            <Game>SADX</Game>
+            <Game>Sonic Adventure (DX): Director's Cut</Game>
+            <Game>Sonic Adventure (DX): Category Extensions</Game>
+            <Game>Sonic Adventure DX: Category Extensions</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Sora-yx/autosplitters/master/Sonic%20Adventure%20DX-%20Director-s%20Cut/LiveSplit.SADX.asl</URL>


### PR DESCRIPTION
Added multiple names to the Sonic Adventure DX autosplitter to reflect the old game name Sonic Adventure (DX), the new name Sonic Adventure DX: Director's Cut as well as possible variants and category extensions. Also merged category extensions and base game to pull from the same autosplitter for future convenience

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [v] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [v] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [v] The Auto Splitter has an open source license that allows anyone to fork and host it.
