### PR TITLE
Create CI job to format `LiveSplit.AutoSplitters.xml`

### DIFF
--- a/.github/workflows/format-xml.yml
+++ b/.github/workflows/format-xml.yml
@@ -1,0 +1,28 @@
+name: Format XML File
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'LiveSplit.AutoSplitters.xml'
+
+jobs:
+  format:
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Format .xml file with yq
+      uses: mikefarah/yq@v4.35.2
+      with:
+        cmd: yq -i -ox -I4 '.' LiveSplit.AutoSplitters.xml
+
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9.1.3
+      with:
+        author_name: github-actions
+        author_email: 41898282+github-actions[bot]@users.noreply.github.com
+        message: Automatic formatting of XML


### PR DESCRIPTION
This PR creates a CI job which formats the `LiveSplit.AutoSplitters.xml` file. This job has been tested.  
It:
- indents entries correctly (4 spaces)
- removes blank lines
- removes trailing whitespace

The job is ran only when a pull request was merged and `LiveSplit.AutoSplitters.xml` had changes.