### PR TITLE
Add autosplitter for Marble It Up! Ultra

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16950,6 +16950,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Marble It Up! Ultra</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/thearst3rd/autosplitters/main/LiveSplit.MarbleItUpUltra.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/Components/UnityASL.bin</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Supports auto start, and splits on finishing and treasure box collection. (by thearst3rd, TalentedPlatinum, Ero)</Description>
+        <Website>https://github.com/TalentedPlatinum/AutoSplitters/blob/main/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Marble Blast Gold</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
This builds off the great autosplitter for Marble It Up! (now "Marble It Up! Classic") by @TalentedPlatinum and Ero. Many aspect of the original autosplitter worked totally fine on the new version. Some debouncing was needed on splits, with my best guess being the new server+client oriented nature of Ultra. I also added support for splitting on treasure boxes.

------

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
