### PR TITLE
Update locations for my autosplitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7015,7 +7015,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Split, start, and reset available. (By hatkirby)</Description>
-        <Website>https://code.fourisland.com/autosplitters/</Website>
+        <Website>https://code.fourisland.com/autosplitters/about</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -18229,7 +18229,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Split, start, and load removal available. (By hatkirby)</Description>
-        <Website>https://code.fourisland.com/autosplitters/</Website>
+        <Website>https://code.fourisland.com/autosplitters/about</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -18350,7 +18350,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Start, split, and load removal available. (By hatkirby)</Description>
-        <Website>https://code.fourisland.com/autosplitters/</Website>
+        <Website>https://code.fourisland.com/autosplitters/about</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -18803,7 +18803,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Start and split available. (By hatkirby)</Description>
-        <Website>https://code.fourisland.com/autosplitters/</Website>
+        <Website>https://code.fourisland.com/autosplitters/about</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7010,12 +7010,12 @@
             <Game>Manifold Garden</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/hatkirby/autosplitters/main/Manifold%20Garden.asl</URL>
+            <URL>https://code.fourisland.com/autosplitters/plain/Manifold%20Garden.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/main/lib/LiveSplit.ASLHelper.bin</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Split, start, and reset available. (By hatkirby)</Description>
-        <Website>https://github.com/hatkirby/autosplitters</Website>
+        <Website>https://code.fourisland.com/autosplitters/</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -18224,12 +18224,12 @@
             <Game>The Looker</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/hatkirby/autosplitters/main/TheLooker.asl</URL>
+            <URL>https://code.fourisland.com/autosplitters/plain/TheLooker.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/main/lib/LiveSplit.ASLHelper.bin</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Split, start, and load removal available. (By hatkirby)</Description>
-        <Website>https://github.com/hatkirby/autosplitters</Website>
+        <Website>https://code.fourisland.com/autosplitters/</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -18346,11 +18346,11 @@
             <Game>Taiji</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/hatkirby/autosplitters/main/Taiji.asl</URL>
+            <URL>https://code.fourisland.com/autosplitters/plain/Taiji.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Start, split, and load removal available. (By hatkirby)</Description>
-        <Website>https://github.com/hatkirby/autosplitters</Website>
+        <Website>https://code.fourisland.com/autosplitters/</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -18799,11 +18799,11 @@
             <Game>Lingo Custom Maps</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/hatkirby/autosplitters/main/Lingo.asl</URL>
+            <URL>https://code.fourisland.com/autosplitters/plain/Lingo.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Start and split available. (By hatkirby)</Description>
-        <Website>https://github.com/hatkirby/autosplitters</Website>
+        <Website>https://code.fourisland.com/autosplitters/</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

I am moving my autosplitters off of GitHub, and so I am updating the URLs here to point to their new locations.