### PR TITLE
Replace all Tony Hawk's series autosplitters with new ASR splitter, add Mat Hoffman's Pro BMX, Tony Hawk's American Wasteland, Tony Hawk's Pro Skater 1+2

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6932,7 +6932,8 @@
         <URLs>
             <URL>https://github.com/PARTYMANX/thps-autosplitter/releases/latest/download/thps_autosplitter.wasm</URL>
         </URLs>
-        <Type>AutoSplittingRuntime</Type>
+        <Type>Script</Type>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
         <Description>Auto Splitting, Load Removal, and Auto Start/Reset are available. (By PARTY MAN X.  THPS4, THUG1, THUG2 based on work by Fog)</Description>
         <Website>https://github.com/PARTYMANX/thps-autosplitter</Website>
     </AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6943,20 +6943,22 @@
             <Game>Tony Hawk's Pro Skater 3</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/RisingFog/LiveSplit-AutoSplitters/master/THPS3.asl</URL>
+            <URL>https://github.com/PARTYMANX/thps-autosplitter/releases/latest/download/thps_autosplitter.wasm</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting, Load Removal, and Auto Start/Reset are available. (By Fog)</Description>
+        <Description>Auto Splitting, Load Removal, and Auto Start/Reset are available. (By PARTY MAN X (based on work by Fog))</Description>
+        <Website>https://github.com/PARTYMANX/thps-autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Tony Hawk's Pro Skater 4</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/RisingFog/LiveSplit-AutoSplitters/master/THPS4.asl</URL>
+            <URL>https://github.com/PARTYMANX/thps-autosplitter/releases/latest/download/thps_autosplitter.wasm</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting and Auto Start are available. (By Fog)</Description>
+        <Description>Auto Splitting, Load Removal, and Auto Start/Reset are available. (By PARTY MAN X (based on work by Fog))</Description>
+        <Website>https://github.com/PARTYMANX/thps-autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6627,26 +6627,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Tony Hawk's Underground</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/RisingFog/LiveSplit-AutoSplitters/master/THUG.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting and Auto Start/Reset are available. (By Fog)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Tony Hawk's Underground 2</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/RisingFog/LiveSplit-AutoSplitters/master/THUG2.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting and Auto Start/Reset are available. (By Fog)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Undead Rider Asylum</Game>
         </Games>
         <URLs>
@@ -6940,35 +6920,21 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Tony Hawk's Pro Skater 3</Game>
-        </Games>
-        <URLs>
-            <URL>https://github.com/PARTYMANX/thps-autosplitter/releases/latest/download/thps_autosplitter.wasm</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting, Load Removal, and Auto Start/Reset are available. (By PARTY MAN X (based on work by Fog))</Description>
-        <Website>https://github.com/PARTYMANX/thps-autosplitter</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Tony Hawk's Pro Skater 4</Game>
-        </Games>
-        <URLs>
-            <URL>https://github.com/PARTYMANX/thps-autosplitter/releases/latest/download/thps_autosplitter.wasm</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting, Load Removal, and Auto Start/Reset are available. (By PARTY MAN X (based on work by Fog))</Description>
-        <Website>https://github.com/PARTYMANX/thps-autosplitter</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Tony Hawk's Pro Skater 2</Game>
+            <Game>Tony Hawk's Pro Skater 3</Game>
+            <Game>Tony Hawk's Pro Skater 4</Game>
+            <Game>Tony Hawk's Underground</Game>
+            <Game>Tony Hawk's Underground 2</Game>
+            <Game>Tony Hawk's American Wasteland</Game>
+            <Game>Tony Hawk's Pro Skater 1+2</Game>
+            <Game>Mat Hoffman's Pro BMX</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/RisingFog/LiveSplit-AutoSplitters/master/THPS2.asl</URL>
+            <URL>https://github.com/PARTYMANX/thps-autosplitter/releases/latest/download/thps_autosplitter.wasm</URL>
         </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting and Auto Start are available. (By Fog)</Description>
+        <Type>AutoSplittingRuntime</Type>
+        <Description>Auto Splitting, Load Removal, and Auto Start/Reset are available. (By PARTY MAN X.  THPS4, THUG1, THUG2 based on work by Fog)</Description>
+        <Website>https://github.com/PARTYMANX/thps-autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18586,4 +18586,15 @@
         <Description>Basic AutoSplitter with Start/Pause timer during race. Ensure LiveSplit Compare Against is set to: Game Time</Description>
         <Website>https://github.com/JakeRabinowitz/PogoChampAutosplitter</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Only Up!</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Edgarflc/autosplitter_only_up/main/OnlyUp!.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter with Start, Reset and configurable Splits (by traumvogel, t0mz3r, NeKRooZz and wRadion)</Description>
+        <Website>https://github.com/Edgarflc/autosplitter_only_up</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7534,7 +7534,7 @@
         </URLs>
         <Type>Script</Type>
         <ScriptType>AutoSplittingRuntime</ScriptType>
-        <Description>Auto Splitting, Load Removal, and Auto Start/Reset are available. (By PARTY MAN X.  THPS4, THUG1, THUG2 based on work by Fog)</Description>
+        <Description>Autosplitting, Load Removal, and Auto Start/Reset are available. (By PARTY MAN X. Parts based on work by Fog)</Description>
         <Website>https://github.com/PARTYMANX/thps-autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18597,4 +18597,16 @@
         <Description>Autosplitter with Start, Reset and configurable Splits (by traumvogel, t0mz3r, NeKRooZz and wRadion)</Description>
         <Website>https://github.com/Edgarflc/autosplitter_only_up</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Oblivion Override</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/CptBrian/Autosplitters/master/OblivionOverride.asl</URL>
+	    <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Oblivion Override (PC) Autosplitter (By CptBrian and Ero)</Description>
+        <Website>https://www.speedrun.com/oblivion_override</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
