### PR TITLE
Added Inspector Gadget (SNES)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Inspector Gadget</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Thedragon005/InspectorGadget_AutoSplitter/main/InspectorGadget_AS.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Full Autosplitter by Thedragon005</Description>
+        <Website>https://www.speedrun.com/inspector_gadget</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Peter Jackson's King Kong</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Added game Inspector Gadget

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
