### PR TITLE
Update SADX CE games list

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4101,6 +4101,9 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Sonic Adventure DX - Category Extensions</Game>
+            <Game>SADX - Category Extensions</Game>
+            <Game>SADXCE</Game>
             <Game>Sonic Adventure (DX) - Category Extensions</Game>
             <Game>Sonic Adventure (DX): Category Extensions</Game>
             <Game>Sonic Adventure DX: Category Extensions</Game>


### PR DESCRIPTION
This changes the recognized game names for the Sonic Adventure DX - Category Extensions leaderboard as the speedrun.com page for the game just had a name change.

Here is the approval of Tethys, the mod that requested that we take a look at this:

![image](https://github.com/LiveSplit/LiveSplit.AutoSplitters/assets/38794835/fd48199a-caf0-4a87-a93e-c1d283035316)


If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
