### PR TITLE
Add SADX DC conversion game to SADX

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4091,6 +4091,7 @@
             <Game>Sonic Adventure DX Director's Cut</Game>
             <Game>SADX</Game>
             <Game>Sonic Adventure (DX): Director's Cut</Game>
+            <Game>Sonic Adventure DX: Dreamcast Conversion</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Sora-yx/autosplitters/master/Sonic%20Adventure%20DX-%20Director-s%20Cut/LiveSplit.SADX.asl</URL>


### PR DESCRIPTION
This adds the Sonic Adventure DX: Dreamcast Conversion game to the list of games of the Sonic Adventure DX auto splitter.

These changes were made after Tethys, a moderator for this game asked me to do this, here is a screenshot of the related conversation for proof:

![image](https://github.com/LiveSplit/LiveSplit.AutoSplitters/assets/38794835/14c40592-b0d7-44a6-b301-9890a990995c)


If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
