### PR TITLE
Replace heavily outdated FNaF World autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10408,11 +10408,11 @@
             <Game>FNaF World Category Extensions</Game>
         </Games>
         <URLs>
-            <URL>https://gitlab.com/supramayro/fnaf-world-autosplitter/raw/master/FNaF_World.asl</URL>
+            <URL>https://raw.githubusercontent.com/AITYunivers/FNaFSpeedrunStuff/main/FNaF%20World/FNaF%20World%20Autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Removal and Auto Split, Start, and Reset are available. (by Supra)</Description>
-        <Website>https://gitlab.com/supramayro/fnaf-world-autosplitter</Website>
+        <Description>Updated Auto Splitter for FNaF World. Supports all versions. Exe must be named "FNaF_World.exe" like on Steam</Description>
+        <Website>https://github.com/AITYunivers/FNaFSpeedrunStuff</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
The old autosplitter was made 5 years ago, and doesn't actually support end splits for most categories. This one is the one the community actually uses, and is the one listed on the Speedrun.com resources tab.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
![image](https://github.com/LiveSplit/LiveSplit.AutoSplitters/assets/92553545/cc3e98b8-c60f-4602-9ae7-26ef9355156e)
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
