### PR TITLE
Updating game name for dirt 1 asl

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20299,7 +20299,7 @@
     </AutoSplitter>
     <AutoSplitter>
 	      <Games>
-	        <Game>Colin McRae: Dirt</Game>
+	        <Game>Colin McRae: DIRT</Game>
             <Game>Dirt 1</Game>
 	      </Games>
 	      <URLs>


### PR DESCRIPTION
the name in xml wasn't matching the name in livesplit, sorry for inconvinience

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
