### PR TITLE
Add Autosplitter for Age of Mythology

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,20 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Age of Mythology</Game>
+            <Game>Age of Mythology: The Titans</Game>
+            <Game>Age of Mythology: Extended Edition</Game>
+            <Game>Age of Mythology: Tale of the Dragon</Game>
+            <Game>AOM</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/jbadlato/aom-autosplitter/main/aom-autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting by joeybadz</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Prince of Persia: The Lost Crown</Game>
             <Game>Prince of Persia The Lost Crown</Game>
             <Game>POPTLC</Game>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
