### PR TITLE
Add Twintower autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20707,4 +20707,15 @@
         <Description>Auto Splitter for Obama (by CodeNameMeteor)</Description>
         <Website>https://github.com/CodeNameMeteor/Autosplitters/blob/main/Obama/ObamaAny.asl</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>A Game, Creating twin towers with balancing</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Felicien2B/TwintowerASL/main/twintower.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter for Twintower (Windows) (By Felicien2B and Jean20B)</Description>
+        <Website>https://www.speedrun.com/twintower</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
