### PR TITLE
Change Half-Life 2's default to new fork of SourceSplit

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4776,11 +4776,8 @@
             <Game>Source Engine</Game>
             <Game>Dark Messiah of Might and Magic</Game>
             <Game>E.Y.E: Divine Cybermancy</Game>
-            <Game>Half-Life 2</Game>
-            <Game>Half-Life 2 Category Extensions</Game>
             <Game>Half-Life 2: Episode One</Game>
             <Game>Half-Life 2: Episode Two</Game>
-            <Game>Half-Life 2: Ghosting Mod</Game>
             <Game>Blamod Reborn</Game>
             <Game>FakeFactory's Cinematic Mod</Game>
         </Games>
@@ -7033,6 +7030,9 @@
             <Game>Portal: Prelude</Game>
             <Game>Portal Category Extensions</Game>
             <Game>Portal Mods</Game>
+            <Game>Half-Life 2</Game>
+            <Game>Half-Life 2 Category Extensions</Game>
+            <Game>Half-Life 2: Ghosting Mod</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/thisis2838/SourceSplit/master/update/Components/LiveSplit.SourceSplit.dll</URL>


### PR DESCRIPTION
- Changed Half-Life 2's autosplitter to comply with rule changes.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [v] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [v] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [v] The Auto Splitter has an open source license that allows anyone to fork and host it.
