### PR TITLE
Add ASL for Far Cry Primal

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11466,6 +11466,20 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Far Cry Primal</Game>
+            <Game>FCP</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Binslev/FCPLR/main/FCPrimal.asl</URL>
+            <URL>https://raw.githubusercontent.com/Binslev/FCPLR/main/FCPrimal.Settings.xml</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Remover & Autosplitter is available (By Vlad2D)</Description>
+        <Website>https://discord.gg/HRHy7pbqUh</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Far Cry 5</Game>
             <Game>FC5</Game>
         </Games>


### PR DESCRIPTION
ASL includes both load remover and autosplitter. Settings are in a separate XML file, to keep the ASL legible.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
