### PR TITLE
Updating location and description of Prince of Persia series ASLs

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8803,10 +8803,10 @@
             <Game>POP: The Forgotten Sands</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Sands-of-Time-Autosplitter/master/TFSsplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_tfs.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autostart/reset/split by Samabam and Load removal (by SuicideMachine)</Description>
+        <Description>Automatic start, split, reset and load-removal (by Samabam and SuicideMachine)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -10860,10 +10860,10 @@
             <Game>POP: Sands of Time</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Sands-of-Time-Autosplitter/master/POPSandsOfTimeAnyZipless_v3.4.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_sot.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting (with sub/category detection) is available. (By Samabam and Ynscription)</Description>
+        <Description>Automatic start, split and reset (by Samabam and Ynscription)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -10945,10 +10945,10 @@
             <Game>Prince of Persia Two Thrones</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Sands-of-Time-Autosplitter/master/POPTwoThrones.ASL</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_t2t.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting (with sub/category detection) is available. (By Samabam)</Description>
+        <Description>Automatic start, split and reset (by Samabam)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -12159,12 +12159,13 @@
     <AutoSplitter>
         <Games>
             <Game>Prince of Persia 2008</Game>
+            <Game>Prince of Persia (2008)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Sands-of-Time-Autosplitter/master/PoP2k8.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_2008.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Any% Autosplit, Autostart, Autoreset</Description>
+        <Description>Automatic start, split and reset (by Samabam)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -12244,10 +12245,10 @@
             <Game>Prince of Persia 3D</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Sands-of-Time-Autosplitter/master/pop3d.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_3d.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load/Crash Removal</Description>
+        <Description>Automatic start, split, reset and load-removal (by Samabam)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -13573,10 +13574,10 @@
             <Game>Multi-Prince of Persia-Runs</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Multi-PoP-Autosplitter/master/MultiPoPSandsTrilogy.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/multipop.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter and IGT/Load-remover for the 7 major categories. (by Samabam, Smathlax, GMP, et al.)</Description>
+        <Description>Automatic start, split and load-removal/IGT (by Samabam, Smathlax, GMP, et al.)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -13776,10 +13777,10 @@
             <Game>Prince of Persia: The Fallen King</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Multi-PoP-Autosplitter/master/TFK_Final.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_tfk.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter and in-game timer are available (By NoTeefy, GMP and Smathlax)</Description>
+        <Description>Automatic start, split and IGT for emulator runs on DeSmuME 0.9.9 (by NoTeefy, GMP and Smathlax)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -14916,10 +14917,10 @@
             <Game>Prince of Persia 2</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Sands-of-Time-Autosplitter/master/pop2.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autospliter for Prince of Persia 2IR on DOSBox 0.74-3 (In-game timer)</Description>
+        <Description>Automatic start, split, reset and IGT for the IR version on DOSBox 0.74-3 (by Samabam and WinterThunder)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -16480,10 +16481,10 @@
             <Game>Prince of Persia Arabian Nights</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/samabam/Sands-of-Time-Autosplitter/master/pop_an.asl</URL>
+            <URL>https://github.com/PoPRuns/PoP.AutoSplitters/blob/main/pop_an.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter (by Rythin and Tocaloni1)</Description>
+        <Description>Automatic start and split (by rythin and toca)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -17113,12 +17114,13 @@
     <AutoSplitter>
         <Games>
             <Game>Prince of Persia (Apple ][)</Game>
+            <Game>Prince of Persia (Apple II)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/GMPranav/ASLs/main/PrinceOfPersiaApple%5D%5B.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop1_apple.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter and IGT for the Apple ][ version of Prince of Persia on AppleWin 1.30.3</Description>
+        <Description>Automatic start, split, reset and IGT for the Apple ][ version of Prince of Persia on AppleWin 1.30.3 (by GMP)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16481,7 +16481,7 @@
             <Game>Prince of Persia Arabian Nights</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/PoPRuns/PoP.AutoSplitters/blob/main/pop_an.asl</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_an.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Automatic start and split (by rythin and toca)</Description>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Recently, we created the "PoPRuns" GitHub organization, so me and @samabam decided to move the move the various Prince of Persia scripts scattered across repos into one consolidated repo - https://github.com/PoPRuns/PoP.AutoSplitters
It currently contains the vast majority of the Prince of Persia series, the only exceptions being PoP1 (DOS) and PoP: WW
I have also done some other sematic changes like homogenizing the descriptions and adding some aliases for some games.
