### PR TITLE
Assassins Creed Liberation Remastered Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20823,7 +20823,7 @@
             <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Syndicate/main/ACS.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitter for Assassins Creed Syndicate Jack the ripper DLC (by TpRedNinja)</Description>
+        <Description>Auto Splitter for Assassins Creed Syndicate(by TpRedNinja)</Description>
         <Website>https://github.com/TpRedNinja/Assassins-Creed-Syndicate/blob/main/ACS.asl</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -20922,5 +20922,16 @@
         </URLs>
         <Type>Script</Type>
         <Description>Starts on Conductor, splits on level change, removes loads. (By WillTRM)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed III Remastered</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Liberation.asl/main/ACL.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitter for Assassins Creed Liberation Remastered(by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Syndicate/blob/main/ACS.asl</Website>
     </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20823,7 +20823,7 @@
             <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Syndicate/main/ACS.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitter for Assassins Creed Syndicate(by TpRedNinja)</Description>
+        <Description>Auto Splitter for Assassins Creed Syndicate (by TpRedNinja)</Description>
         <Website>https://github.com/TpRedNinja/Assassins-Creed-Syndicate/blob/main/ACS.asl</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
Fixed description for the syndicate one so it no longer includes the dlc title as it works for the dlc and base game for steam and Ubisoft connect. Also added a autosplitter for Assassins creed Liberation Remastered. But note on speedrun.com and in turn for live split you put put the game on Assassins Creed III Remastered and then select the category as Liberation any%/100%. So that's why i didn't put the game as Assassins Creed Liberation Remastered.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
