### PR TITLE
Updated PoP:Warrior Within location, added PoP1 SNES

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10961,11 +10961,10 @@
             <Game>Prince of Persia Warrior Within</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/Cred1Tor/Autosplitters/master/POPWarriorWithin_Pog.ASL</URL>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_ww.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto splitting, auto starting, auto resetting are available. (By Creditor)</Description>
-        <Website>https://github.com/Cred1Tor/Autosplitters</Website>
+        <Description>Automatic start, split and reset (by Creditor)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -17164,7 +17163,18 @@
             <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop1_apple.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Automatic start, split, reset and IGT for the Apple ][ version of Prince of Persia on AppleWin 1.30.3 (by GMP)</Description>
+        <Description>Automatic start, split, reset and IGT for the Apple ][ version on AppleWin 1.30.3 (by GMP)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Prince of Persia (SNES)</Game>
+            <Game>Prince of Persia SNES</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop1_snes.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Automatic start, split and reset for the SNES version on snes9x 1.60 (by Dávid Nagy, Shauing and GMP)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
I declare that:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself.
- [x] I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

(hopefully) the last Prince of Persia PR for now, I promise...

Changes:
- Moved Warrior Within asl to the new repo as well (with permission from Creditor)
- Added PoP1 SNES asl
- Updated description to match the format

And with that all of the Prince of Persia series games that have a script should be covered.
