### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13,6 +13,7 @@
     <AutoSplitter>
         <Games>
             <Game>Mad Max</Game>
+            <Game>Mad Max (2015)</Game>
         </Games>
         <URLs>
             <URL>https://github.com/plyd823/MadMaxAutosplitter/raw/main/MadMaxAutosplitter.asl</URL>


### PR DESCRIPTION
Adds Mad Max (2015) to the mad max autosplitter games list

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
