### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11597,10 +11597,12 @@
             <Game>FC4</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/AlexYeahNot/asl-scripts/master/FC4.asl</URL>
+            <URL>https://raw.githubusercontent.com/Binslev/FC4LR/main/FC4.asl</URL>
+            <URL>https://raw.githubusercontent.com/Binslev/FC4LR/main/FC4.Settings.xml</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>LoadRemover (v1.4.0) is available (by AlexYeahNot)</Description>
+        <Description>Load Remover and Autosplitter is available (By Binslev)</Description>
         <Website>https://discord.gg/D7vJsC</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
Overhauled Far Cry 4 ASL.
- added autosplitter for patch 1.4 and 1.10.
- added load remover for patch 1.7 and 1.10.
- Added case switches for the different versions, as well as other QoL changes.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
