### PR TITLE
Added Tomb Raider I-III Remastered Starring Lara Croft

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21130,13 +21130,47 @@
         <Games>
             <Game>Tomb Raider I-III Remastered Starring Lara Croft</Game>
             <Game>Tomb Raider 1-3 Remastered Starring Lara Croft</Game>
+            <Game>TR 1-3 Remastered Starring Lara Croft</Game>
             <Game>Tomb Raider I-III Remastered</Game>
             <Game>Tomb Raider 1-3 Remastered</Game>
+            <Game>TR 1-3 Remastered</Game>
             <Game>Tomb Raider Remastered I-III</Game>
             <Game>Tomb Raider Remastered 1-3</Game>
             <Game>TRR I-III</Game>
             <Game>TRR 123</Game>
             <Game>TR123</Game>
+            <Game>TR123R</Game>
+            <Game>Tomb Raider I Remastered</Game>
+            <Game>Tomb Raider 1 Remastered</Game>
+            <Game>TR1 Remastered</Game>
+            <Game>TR1R</Game>
+            <Game>Tomb Raider: Unfinished Business Remastered</Game>
+            <Game>Tomb Raider Unfinished Business Remastered</Game>
+            <Game>TR:UB Remastered</Game>
+            <Game>TRUB Remastered</Game>
+            <Game>TRUBR</Game>
+            <Game>Tomb Raider II Remastered</Game>
+            <Game>Tomb Raider 2 Remastered</Game>
+            <Game>TR2 Remastered</Game>
+            <Game>TR2R</Game>
+            <Game>Tomb Raider II Gold Remastered</Game>
+            <Game>Tomb Raider 2 Gold Remastered</Game>
+            <Game>Tomb Raider II: Golden Mask Remastered</Game>
+            <Game>Tomb Raider 2: Golden Mask Remastered</Game>
+            <Game>TRII Gold Remastered</Game>
+            <Game>TR2 Gold Remastered</Game>
+            <Game>TRII: Golden Mask Remastered</Game>
+            <Game>TR2: Golden Mask Remastered</Game>
+            <Game>Tomb Raider III Remastered</Game>
+            <Game>Tomb Raider 3 Remastered</Game>
+            <Game>TR3 Remastered</Game>
+            <Game>TR3R</Game>
+            <Game>Tomb Raider: The Lost Artifact Remastered</Game>
+            <Game>Tomb Raider The Lost Artifact Remastered</Game>
+            <Game>TR: The Lost Artifact Remastered</Game>
+            <Game>TR The Lost Artifact Remastered</Game>
+            <Game>TR:TLA Remastered</Game>
+            <Game>TLA Remastered</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TR123/Components/TR123.dll</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21176,7 +21176,7 @@
             <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TR123/Components/TR123.dll</URL>
         </URLs>
         <Type>Component</Type>
-        <Description>Automatic Start, Split, and optional reset with IGT and RTA w/o Loads support for FG, IL, and deathruns. By Midge and apel.</Description>
+        <Description>Automatic Start, Split, and optional Reset. IGT and RTA w/o Loads. FG, IL, and deathruns. By Midge and apel.</Description>
         <Website>https://github.com/TombRunners/Autosplitters</Website>
     </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21126,4 +21126,23 @@
         <Description>Autosplitter and Load Removal (By DeathHound6)</Description>
         <Website>https://www.speedrun.com/alice2010</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Tomb Raider I-III Remastered Starring Lara Croft</Game>
+            <Game>Tomb Raider 1-3 Remastered Starring Lara Croft</Game>
+            <Game>Tomb Raider I-III Remastered</Game>
+            <Game>Tomb Raider 1-3 Remastered</Game>
+            <Game>Tomb Raider Remastered I-III</Game>
+            <Game>Tomb Raider Remastered 1-3</Game>
+            <Game>TRR I-III</Game>
+            <Game>TRR 123</Game>
+            <Game>TR123</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TombRunners/autosplitters/master/TR123/Components/TR123.dll</URL>
+        </URLs>
+        <Type>Component</Type>
+        <Description>Automatic Start, Split, and optional reset with IGT and RTA w/o Loads support for FG, IL, and deathruns. By Midge and apel.</Description>
+        <Website>https://github.com/TombRunners/Autosplitters</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
  * MIT

Note:
The large set of game names is due to the nature of the release. It includes the first 3 Tomb Raider games and each game's standalone expansion, totaling 6 distinct bundled games. Runners might choose to search for only the game they wish to run, or they might do a multi-game run and wish to use the entire release name.
So, the `games` entries are meant to be a reasonable set of possible acronym/name combos.