### PR TITLE
Replacing RE1make Splitter with most current version & Load Remover

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5119,12 +5119,16 @@
             <Game>Resident Evil / biohazard HD REMASTER</Game>
             <Game>REmaster</Game>
             <Game>REHD</Game>
+            <Game>RE1make</Game>
+            <Game>Resident Evil HD Remaster (Steam)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/fatalis/ASL/master/REmaster.asl</URL>
+            <URL>https://raw.githubusercontent.com/TheDementedSalad/RE1make-Autosplitter/main/Resident%20Evil%201%20Remake.asl</URL>
+            <URL>https://raw.githubusercontent.com/TheDementedSalad/RE1make-Autosplitter/main/RE1make.Settings.xml</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Automatic Timer Start and Game Time is available. (By Fatalis)</Description>
+        <Description>Auto Splitting and Load Removal available. Compare to IGT. (By CursedToast &amp; Skhowl &amp; TheDementedSalad)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.
