### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13486,7 +13486,7 @@
             <Game>ShadowFlare</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/BurrowBird/Splitters/master/SF_Auto_Splitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/BurrowBird/Splitters/master/SF_Auto_Splitter_v7%202024-03-23.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto-splitting and start is available. (by BurrowBird)</Description>


### PR DESCRIPTION
Updated my ShadowFlare auto splitter. It now supports loading time removal (game time).

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [✓] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [✓] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [✓] The Auto Splitter has an open source license that allows anyone to fork and host it.
