### PR TITLE
Add ASL helper in Smol Ame

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18908,9 +18908,11 @@
     <AutoSplitter>
         <Games>
             <Game>Smol Ame</Game>
+            <Game>Smol Ame Category Extension</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/szczoo17/autosplitters/main/Smol%20Ame/smol_ame.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitter is available (by BloodyRedditor and Skoczek)</Description>


### PR DESCRIPTION
Adds ASL helper in Smol Ame. Also adds category extension.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
