### PR TITLE
Updated Website on Far Cry and Crysis games

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3122,6 +3122,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Load Remover is available. Created by Meta, Binslev and AlexYeahNot.</Description>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -7097,6 +7098,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Load Removal is available. Requires patch 1.1. (By Jukspa)</Description>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -8221,6 +8223,7 @@
         </URLs>
         <Type>Component</Type>
         <Description>Auto Splitting and Load Removal are available. (By btbd)</Description>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11167,6 +11170,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Load time removing and auto splitting by ChickenBoh</Description>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11177,6 +11181,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Load time removing by ChickenBoh</Description>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11738,7 +11743,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitter/LoadRemover is available (by AlexYeahNot )</Description>
-        <Website>https://discord.gg/D7vJsC</Website>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11750,7 +11755,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Loadremover and Autosplitter for FC3:BD (by Vlad2D, AlexYeahNot, Marijn)</Description>
-        <Website>https://discord.gg/HRHy7pbqUh</Website>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11764,7 +11769,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Load Remover and Autosplitter is available (By Binslev)</Description>
-        <Website>https://discord.gg/D7vJsC</Website>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11778,7 +11783,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Load Remover and Autosplitter is available (By Vlad2D)</Description>
-        <Website>https://discord.gg/HRHy7pbqUh</Website>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11790,7 +11795,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>LoadRemover is available (by Binslev, credit to AlexYeahNot)</Description>
-        <Website>https://discord.gg/D7vJsC</Website>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11804,7 +11809,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>LoadRemover is available (by ChiefSupreme, credit to AlexYeahNot)</Description>
-        <Website>https://discord.gg/D7vJsC</Website>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -12981,6 +12986,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Load removal and autosplitting are available - requires 64-bit 1.1 Hotfix version (By SuicideMachine)</Description>
+        <Website>https://discord.gg/sJWVZw6aWq</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
We have had to revoke all invite links to our Cry Running Discord Server, due to frequent spam bots. I have therefore updated the website on all Far Cry and Crysis games in this xml file, as well as adding it to the Far Cry and Crysis games that had no website already.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.
