### PR TITLE
Add CI to the master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - 'master'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Auto Splitters
 
+[![Build Status](https://github.com/LiveSplit/LiveSplit.AutoSplitters/workflows/CI/badge.svg)](https://github.com/LiveSplit/LiveSplit.AutoSplitters/actions)
+
 <!-- TOC depth:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Features of an Auto Splitter](#features-of-an-auto-splitter)


### PR DESCRIPTION
This makes it easier to make sure that the AutoSplitters XML is always in a good state