### PR TITLE
Remove Diablo II: Resurrected autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -17403,17 +17403,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Diablo II: Resurrected</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/WafuRuns/ASLScripts/master/LiveSplit.Diablo2Resurrected.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Load removal (by Wafu)</Description>
-        <Website>https://github.com/WafuRuns/ASLScripts</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Ace Combat 7</Game>
             <Game>Ace Combat 7: Skies Unknown</Game>
         </Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Removing the autosplitter as the community now has a different solution to tracking time and having the option to turn this one on was confusing and distracting.