### PR TITLE
Added Pampas & Selene

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
     <AutoSplitter>
+        
+        
         <Games>
             <Game>Crow Country</Game>
         </Games>
@@ -20281,6 +20283,18 @@
         </URLs>
         <Type>Script</Type>
         <Description>AutoSplitter for Mini Ghost (by NickRPGreen)</Description>
+        <Website>https://unepic-speedruns.fandom.com/wiki/Mini_Ghost</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Pampas & Selene: The Maze of Demons</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/NickRPGreen/Pampas-Selene-Autosplitter/main/Pampas__Selene_Autosplitter_v1.00.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter for Pampas & Selene (by NickRPGreen)</Description>
+        <Website>https://unepic-speedruns.fandom.com/wiki/Pampas_%26_Selene</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Added Pampas and Selene autosplitter (lines 20288-20298) 
Also added website to Mini Ghost (line 20286)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
