### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>The Hive</Game>
+            <Game>TheHive</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/okunzd/The-Hive-Autosplitter/main/TheHiveAutosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart, Autosplit & Autoreset by kunzd</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Tiny Terry's Turbo Trip</Game>
             <Game>Tiny Terrys Turbo Trip</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9,7 +9,7 @@
             <URL>https://raw.githubusercontent.com/okunzd/The-Hive-Autosplitter/main/TheHiveAutosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autostart, Autosplit & Autoreset by kunzd</Description>
+        <Description>Autostart, Autosplit &amp; Autoreset by kunzd</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Autosplitter for The Hive 
https://www.speedrun.com/thehive

I don't know if I needed to add the URL "https://github.com/just-ero/asl-help/raw/main/lib/asl-help"
Or add the website "https://www.speedrun.com/thehive" 
Thanks for any help :)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
