### PR TITLE
Update Max Payne 1 ASL script

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8883,13 +8883,14 @@
     <AutoSplitter>
         <Games>
             <Game>Max Payne</Game>
+            <Game>Max Payne 1</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/zoton2/LiveSplit.Scripts/master/Release/LiveSplit.MaxPayne.asl</URL>
+            <URL>https://raw.githubusercontent.com/thekovic/ASL-Autosplitters/main/MaxPayne1.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Removal is available. (By zoton2)</Description>
-        <Website>https://github.com/zoton2/LiveSplit.Scripts</Website>
+        <Description>Load Removal and Auto Splitting is available. (By Endurance)</Description>
+        <Website>https://github.com/thekovic/LiveSplit.AutoSplitters</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Updates the load remover for Max Payne 1 to a brand new script including autostart, autosplit, autoreset, IL mode, and more. Hosted and submitted with permission from Endurance (the author) and the rest of the Max Payne 1 speedrun leaderboard moderation team.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
