### PR TITLE
adds Eiyuden Chronicle Load Remover

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20534,6 +20534,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Eiyuden Chronicle: Hundred Heroes</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/Eein/eiyuden-chronicle-autosplitter-wasm/releases/latest/download/eiyuden_chronicle_autosplitter_wasm.wasm</URL>
+        </URLs>
+        <Type>Script</Type>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Load Removal (by SuperFamicom)</Description>
+        <Website>https://github.com/Eein/eiyuden-chronicle-autosplitter-wasm</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Live A Live (2022)</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
