### PR TITLE
Fix my auto-spitting runtime links

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6,7 +6,7 @@
             <Game>Snap the Sentinel (Demo)</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/mitchell-merry/livesplit-zdoom/releases/download/latest/snap_the_sentinel.wasm</URL>
+            <URL>https://github.com/mitchell-merry/livesplit-zdoom/releases/latest/download/snap_the_sentinel.wasm</URL>
         </URLs>
         <Type>Script</Type>
         <ScriptType>AutoSplittingRuntime</ScriptType>
@@ -29,7 +29,7 @@
             <Game>Dismantled</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/mitchell-merry/livesplit-zdoom/releases/download/latest/dismantled.wasm</URL>
+            <URL>https://github.com/mitchell-merry/livesplit-zdoom/releases/latest/download/dismantled.wasm</URL>
         </URLs>
         <Type>Script</Type>
         <ScriptType>AutoSplittingRuntime</ScriptType>
@@ -3201,7 +3201,7 @@
             <Game>Selaco</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/mitchell-merry/livesplit-zdoom/releases/download/latest/selaco.wasm</URL>
+            <URL>https://github.com/mitchell-merry/livesplit-zdoom/releases/latest/download/selaco.wasm</URL>
         </URLs>
         <Type>Script</Type>
         <ScriptType>AutoSplittingRuntime</ScriptType>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Oops.