### PR TITLE
Add POD: Planet of Death auto splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -22203,4 +22203,14 @@
         <Type>Script</Type>
         <Description>Auto splitter by Niko Salocin</Description>
      </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>POD: Planet of Death</Game>
+        </Games>
+        <URLs>
+            <URL>https://gitlab.com/Syroot/Pod/LiveSplit/-/raw/main/pod.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto splitter for Championships using the In-Game Timer</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Auto splitter for Championships using the In-Game Timer.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it. (MIT, https://gitlab.com/Syroot/Pod/LiveSplit/-/raw/main/LICENSE - please let me know if you require another license.)

`startup` currently sets `timer.CurrentTimingMethod = TimingMethod.GameTime` without asking as real time makes no sense for this game (drifts quickly from in-game timer) and is not accepted on SRC - please let me know if it's recommended to do the `MessageBox` shebang asking the user to change the method and I add it to the script.