### PR TITLE
Add Platform 8 to Autosplitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -22247,4 +22247,14 @@
         <Type>Script</Type>
         <Description>IGT and Autosplitter available for MG2 across all PS2 discs (By TheDementedSalad)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Platform 8</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/luciferofastora/exit-platform-8-autosplit/main/Platform%208.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart, -stop and -reset for Platform 8 (By Lucifer Of Astora)</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Autosplitter for Platform 8, tested and approved by the Platform 8 leaderboard mod ND606

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
