### PR TITLE
Update The Lion King (SNES) autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16301,11 +16301,11 @@
             <Game>The Lion King (SNES)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/kannadan/autosplitter/master/autosplit_lion_king_snes.asl</URL>
+            <URL>https://raw.githubusercontent.com/SBDWolf/ASL-Autosplitters/main/TheLionKingSNES/autosplit_lion_king_snes.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto start and split for snes9x v1.60 and higan v110(by kannadan)</Description>
-        <Website>https://www.speedrun.com/lionkingsnes</Website>
+        <Description>Autosplitting available for some versions of snes9x, bsnes, and higan (by SBDWolf and kannadan)</Description>
+        <Website>https://github.com/SBDWolf/ASL-Autosplitters/tree/main/TheLionKingSNES</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

I have rewritten this autosplitter. Kannadan (kannadan on Discord) no longer wishes to maintain this autosplitter and I have gotten permission from him to replace it and host it myself.