### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16686,13 +16686,16 @@
     <AutoSplitter>
         <Games>
             <Game>Outer Wilds</Game>
+            <Game>Outer Wilds Category Extensions</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/sseneca42/Outer-Wilds-Autosplitter/main/OW_Autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/78epo/Autosplitters/main/Outer%20Wilds/OW_Autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/78epo/Autosplitters/main/Outer%20Wilds/data.owsave</URL>
+            <URL>https://raw.githubusercontent.com/78epo/Autosplitters/main/Outer%20Wilds/OW_Shiplog.csv</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Load Remover and AutoSplitter (by Nepo)</Description>
-        <Website>https://github.com/sseneca42/Outer-Wilds-Autosplitter/blob/main/README.md</Website>
+        <Website>https://github.com/78epo/Autosplitters/tree/main/Outer%20Wilds</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -17343,11 +17346,11 @@
             <Game>Sunblaze</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/sseneca42/Autosplitters/main/Sunblaze/Sunblaze_Autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/78epo/Autosplitters/main/Sunblaze/Sunblaze_Autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>AutoSplitter (by Nepo)</Description>
-        <Website>https://github.com/sseneca42/Autosplitters/tree/main/Sunblaze</Website>
+        <Website>https://github.com/78epo/Autosplitters/tree/main/Sunblaze</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -18147,11 +18150,11 @@
             <Game>Cave Crawler</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/sseneca42/Autosplitters/main/Cave%20Crawler/CaveCrawler_Autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/78epo/Autosplitters/main/Cave%20Crawler/CaveCrawler_Autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>AutoSplitter (by Nepo)</Description>
-        <Website>https://github.com/sseneca42/Autosplitters/tree/main/Cave%20Crawler</Website>
+        <Website>https://github.com/78epo/Autosplitters/tree/main/Cave%20Crawler</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Autosplitters impacted: Outer Wilds, Sunblaze, Cave Crawler

-Changed github username
-Reunited every autosplitter in the same repo
-Added "Outer Wilds Category Extensions" to the Outer Wilds autosplitter
-The Outer Wilds autosplitter now requires 3 files: The main .asl file, the default savefile, and a CSV containing organized information used to create hundreds of splits

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
