### PR TITLE
Replace Halo CE (PC 2003) autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5539,12 +5539,11 @@
             <Game>Halo PC</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/fatalis/HaloSplit/releases/latest/download/LiveSplit.HaloSplit.dll</URL>
-            <URL>https://github.com/fatalis/HaloSplit/releases/latest/download/LiveSplit.HaloSplit.UI.dll</URL>
+            <URL>https://raw.githubusercontent.com/Cambidd/halopc-autosplitter/main/h1pc-autosplitter.asl</URL>
         </URLs>
-        <Type>Component</Type>
-        <Description>Auto Splitting is available. (By Fatalis)</Description>
-        <Website>https://github.com/fatalis/halosplit/blob/master/README.md</Website>
+        <Type>Script</Type>
+        <Description>Autosplitting for Halo: CE (2003 PC version, By Cambid)</Description>
+        <Website>https://github.com/Cambidd/halopc-autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Improved feature set to support all categories instead of just fullgame runs. I have asked Fatalis for permission.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ X] The Auto Splitter has an open source license that allows anyone to fork and host it.
