### PR TITLE
Changing the username on my autosplitters' URLs

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1696,7 +1696,7 @@
             <Game>Amanda The Adventurer</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/Unity.AmandaTheAdventurerFULLGAME.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/Unity.AmandaTheAdventurerFULLGAME.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
@@ -1957,7 +1957,7 @@
             <Game>Boson X</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/Lotech.BosonX.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/Lotech.BosonX.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start and split supported. (By NERS)</Description>
@@ -7780,7 +7780,7 @@
             <Game>Undertale Yellow</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/GameMaker.UndertaleYellow.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/GameMaker.UndertaleYellow.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start, split and reset supported for the full game. (By NERS)</Description>
@@ -7791,7 +7791,7 @@
             <Game>Undertale Yellow (Demo)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/GameMaker.UndertaleYellowDemo.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/GameMaker.UndertaleYellowDemo.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start, split and reset supported for the demo. (By NERS)</Description>
@@ -7803,7 +7803,7 @@
             <Game>TS!Underswap (Demo)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/GameMaker.TSUnderswapDemo.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/GameMaker.TSUnderswapDemo.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start, split and reset supported for the demo. (By NERS)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7032,6 +7032,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Undertale Yellow</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/GameMaker.UndertaleYellow.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start, split and reset supported. (By NERS)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>HorrorTale: Chapter One</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -131,7 +131,7 @@
             <Game>Amanda The Adventurer</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/NERS1111/LiveSplit.AutoSplitters/autosplitters/Unity.AmandaTheAdventurerFULLGAME.asl</URL>
+            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/Unity.AmandaTheAdventurerFULLGAME.asl</URL>
 	    <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
@@ -370,7 +370,7 @@
             <Game>Boson X</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/NERS1111/LiveSplit.AutoSplitters/autosplitters/Lotech.BosonX.asl</URL>
+            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/Lotech.BosonX.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start and split supported. (By NERS)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7268,6 +7268,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>TS!Underswap</Game>
+            <Game>TS!Underswap Demo</Game>
+            <Game>TS!Underswap (Demo)</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/GameMaker.TSUnderswapDemo.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start, split and reset supported for the demo. (By NERS)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>HorrorTale: Chapter One</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1696,7 +1696,7 @@
             <Game>Amanda The Adventurer</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/Unity.AmandaTheAdventurerFULLGAME.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners-xd/Autosplitter.Projects/main/Unity.AmandaTheAdventurerFULLGAME.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
@@ -1957,7 +1957,7 @@
             <Game>Boson X</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/Lotech.BosonX.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners-xd/Autosplitter.Projects/main/Lotech.BosonX.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start and split supported. (By NERS)</Description>
@@ -7780,7 +7780,7 @@
             <Game>Undertale Yellow</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/GameMaker.UndertaleYellow.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners-xd/Autosplitter.Projects/main/GameMaker.UndertaleYellow.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start, split and reset supported for the full game. (By NERS)</Description>
@@ -7791,7 +7791,7 @@
             <Game>Undertale Yellow (Demo)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/GameMaker.UndertaleYellowDemo.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners-xd/Autosplitter.Projects/main/GameMaker.UndertaleYellowDemo.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start, split and reset supported for the demo. (By NERS)</Description>
@@ -7803,7 +7803,7 @@
             <Game>TS!Underswap (Demo)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/ners_xd/Autosplitter.Projects/main/GameMaker.TSUnderswapDemo.asl</URL>
+            <URL>https://raw.githubusercontent.com/ners-xd/Autosplitter.Projects/main/GameMaker.TSUnderswapDemo.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start, split and reset supported for the demo. (By NERS)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7038,7 +7038,18 @@
             <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/GameMaker.UndertaleYellow.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto start, split and reset supported. (By NERS)</Description>
+        <Description>Auto start, split and reset supported for the full game. (By NERS)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Undertale Yellow Demo</Game>
+            <Game>Undertale Yellow (Demo)</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/NERS1111/Autosplitter.Projects/main/GameMaker.UndertaleYellowDemo.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start, split and reset supported for the demo. (By NERS)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- ✅ My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- ✅ I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- ✅ The Auto Splitter has an open source license that allows anyone to fork and host it.

I know I don't have to do this since the links automatically get redirected to the correct username, but I just wanted to make a PR for this for consistency's sake, for when I end up uploading more autosplitters.
