### PR TITLE
Add auto-splitter for Wéko The Mask Gatherer

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -17766,6 +17766,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Wéko The Mask Gatherer</Game>
+            <Game>Weko The Mask Gatherer</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Leemyy/LiveSplit.WekoMaskGatherer/main/Components/LiveSplit.WekoMaskGatherer.dll</URL>
+        </URLs>
+        <Type>Component</Type>
+        <Description>Auto Start/Split/Reset and Load Remover (by Leemyy)</Description>
+        <Website>https://github.com/Leemyy/LiveSplit.WekoMaskGatherer</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Sniper: Path of Vengeance</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Currently supports:
- auto start and reset
- load removal
- fully configurable splitting points

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
