### PR TITLE
Add aliases for Halo Master Chief Collection

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15412,6 +15412,11 @@
     <AutoSplitter>
         <Games>
             <Game>Halo: The Master Chief Collection</Game>
+            <Game>Halo The Master Chief Collection</Game>
+            <Game>Halo: Master Chief Collection</Game>
+            <Game>Halo Master Chief Collection</Game>
+            <Game>Halo: MCC</Game>
+            <Game>Halo MCC</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Burnt-o/MCC_autosplitter/master/MCC_autosplitter.asl</URL>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Halo MCC is not on speedrun.com so it doesn't auto complete, adding a few more aliases so it's easier for people to find.