### PR TITLE
Changed Doom 2016 Repo

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7841,10 +7841,11 @@
             <Game>Doom (2016)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/drtchops/asl/master/doom2016.asl</URL>
+            <URL>https://raw.githubusercontent.com/SabulineHorizon/Autosplitters/main/Doom2016.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal are available. (By DrTChops, TheFuncannon, loitho, sychotixx and Instagibz)</Description>
+        <Description>Auto Start/Split/Reset/Loads (By DrTChops, TheFuncannon, loitho, sychotixx, Instagibz, heny, Meta, SabulineHorizon)</Description>
+        <Website>https://github.com/SabulineHorizon/Autosplitters</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
This change updates the existing autosplitter by replacing it with another repository per the request of the original author. The readme of the original repo reads: "These scripts are no longer maintained. If something needs to be updated, fork the repo or copy the script somewhere else, host it yourself, and point livesplit to the new version." Original repo readme can be found at https://github.com/drtchops/asl/blob/master/README.md

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
