### PR TITLE
Added Die Hard Trilogy PS1 Auto Splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15737,6 +15737,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Die Hard Trilogy</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/kapdap/die-hard-trilogy-ps1-autosplitter/main/die-hard-trilogy-ps1.asl</URL>
+            <URL>https://github.com/Jujstme/emu-help/raw/master/lib/emu-help-v2</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Start and level based Auto Splitting for emulated PS1 releases. (By Kapdap)</Description>
+        <Website>https://github.com/kapdap/die-hard-trilogy-ps1-autosplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>RITE</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
