### PR TITLE
Add IGT scripts for two Prince of Persia games

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,29 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Battles of Prince of Persia</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/bopop.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>IGT for emulator runs on DeSmuME 0.9.9 (by NoTeefy, GMP and Smathlax)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Prince of Persia: The Forgotten Sands (DS)</Game>
+            <Game>Prince of Persia: The Forgotten Sands DS</Game>
+            <Game>Prince of Persia The Forgotten Sands (DS)</Game>
+            <Game>Prince of Persia The Forgotten Sands DS</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/PoPRuns/PoP.AutoSplitters/main/pop_tfs_ds.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>IGT for emulator runs on DeSmuME 0.9.9 (by NoTeefy, GMP and Smathlax)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Sniper Elite</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

This PR adds IGT scripts to the following games:
- Battles of Prince of Persia
- Prince of Persia: The Forgotten Sands (DS)