### PR TITLE
Dead Space (2008): Auto Start and Split by chapter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10351,11 +10351,11 @@
             <Game>Dead Space (2008)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/Mattmatt10111/asl-scripts/master/deadspace.asl</URL>
+            <URL>https://raw.githubusercontent.com/SuiMachine/LiveSplit.ASLScripts/master/Dead-Space-1/Dead-Space-1.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Removal is available (by Mattmatt)</Description>
-        <Website>https://discord.com/invite/BP8TrJ6</Website>
+        <Description>Auto Start and Split by chapter are available (by SuiMachine & Ladamalina)</Description>
+        <Website>https://discord.gg/UxEHpQue</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Add auto splitting functionality. Previous version supports manual splits only.

Tested by Ladamalina, MrKak0ss & Flower during [speedrun tournament](https://docs.google.com/spreadsheets/d/1OmmAI6xzEbfzowbimrp10qIV-i0MUHRPzarc_xwOY8s/edit?gid=634871480#gid=634871480) this autumn.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

--- 

I am ready to add new auto splitter recort to XML if extending any functionality of existing splitters is strictly prohibited.
