### PR TITLE
Replace Knights of The Old Republic Autosplitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6752,11 +6752,11 @@
             <Game>KotOR</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/x-e-r-o/KotOR-Autosplitter/master/K1splitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/kotor-speedruns/Autosplitter/main/K1.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitter is available by Xero. Includes Load Removal by glasnonck.</Description>
-        <Website>https://github.com/x-e-r-o/KotOR-Autosplitter/blob/master/README.md</Website>
+        <Description>Autosplitting for module and Load Removal. By Lane, Xero, and Glasnonck</Description>
+        <Website>https://github.com/kotor-speedruns/Autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -6769,11 +6769,11 @@
             <Game>KotOR 2</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/x-e-r-o/KotOR-Autosplitter/master/K2splitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/kotor-speedruns/Autosplitter/main/K2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitter is available by Xero. Includes Load Removal by glasnonck.</Description>
-        <Website>https://github.com/x-e-r-o/KotOR-Autosplitter/blob/master/README.md</Website>
+        <Description>Autosplitting for module and Load Removal. By Lane, RedMage, the_kovvic, Xero, and Glasnonck.</Description>
+        <Website>https://github.com/kotor-speedruns/Autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter. 
    - Permission granted by Xero, and wider KotOR community with which this collaboration occurred, and still contains much of Xero's work.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
