### PR TITLE
Added .asl extension

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23001,7 +23001,7 @@
             <Game>Squirrel with a Gun</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/SabulineHorizon/Autosplitters/main/SquirrelWithAGun</URL>
+            <URL>https://raw.githubusercontent.com/SabulineHorizon/Autosplitters/main/SquirrelWithAGun.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto start/split/reset (By SabulineHorizon)</Description>


### PR DESCRIPTION
The .asl extension was forgotten when creating the original autosplitter file. This change adds that .asl extension for the sake of consistency.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
