### PR TITLE
Added Supermarket together ASL, updated SCHiM description

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -22786,7 +22786,7 @@
             <URL>https://raw.githubusercontent.com/vojtechblazek/SCHiM-Autosplitter/main/SCHiMASL.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>SCHiM Auto Splitter and Load remover by vojtechblazek</Description>
+        <Description>SCHiM Auto Splitter and Load removal by vojtechblazek</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -23219,6 +23219,6 @@
             <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitter (start & end) by vojtechblazek</Description>
+        <Description>Auto Splitter (start, end) by vojtechblazek</Description>
     </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -22786,7 +22786,7 @@
             <URL>https://raw.githubusercontent.com/vojtechblazek/SCHiM-Autosplitter/main/SCHiMASL.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>SCHiM Auto Splitter by vojtechblazek</Description>
+        <Description>SCHiM Auto Splitter and Load remover by vojtechblazek</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -23209,5 +23209,16 @@
         </URLs>
         <Type>Script</Type>
         <Description>Auto Start/Split and Load removal (By Lyliya)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Supermarket Together</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/vojtechblazek/SupermarketTogether-Autosplitter/refs/heads/main/ASL_SupermarketTogether.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitter (start & end) by vojtechblazek</Description>
     </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Added the autosplitter code  for Supermarket Together. Updated the description of the SCHiM splitter to reflect the fact that it has load removal.

[✔] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself.

[✔] I am not replacing an existing Auto Splitter by a different author.

[✔] The Auto Splitter has an open source license that allows anyone to fork and host it.
