### PR TITLE
Update LiveSplit.AutoSplitters.xml (+ a question)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10695,7 +10695,7 @@
             <URL>https://raw.githubusercontent.com/Thermospore/LiveSplit-asl/refs/heads/master/LiveSplit.Croc_2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto start/split & load removal are available. (By hdc0 + Thermospore)</Description>
+        <Description>Auto start/split &amp; load removal are available. (By hdc0 + Thermospore)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10692,10 +10692,10 @@
             <Game>Croc 2</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/hdc0/LiveSplit-asl/master/LiveSplit.Croc_2.asl</URL>
+            <URL>https://raw.githubusercontent.com/Thermospore/LiveSplit-asl/refs/heads/master/LiveSplit.Croc_2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto starting, splitting and load removal are available. (By hdc0)</Description>
+        <Description>Auto start/split & load removal are available. (By hdc0 + Thermospore)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

---
hdc0 says:

> Make the autosplitter list point to your repo. I haven't updated the autosplitter in over 6 years.

Currently [my repo](https://github.com/Thermospore/LiveSplit-asl) is a fork of hdc0's. Not sure if I should just leave it that way, or turn it into a standalone repo somehow?