### PR TITLE
Fix typo in K2 splitter credits

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6849,7 +6849,7 @@
             <URL>https://raw.githubusercontent.com/kotor-speedruns/Autosplitter/main/K2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitting for module and Load Removal. By Lane, RedMage, the_kovvic, Xero, and Glasnonck.</Description>
+        <Description>Autosplitting for module and Load Removal. By Lane, RedMage, the_kovic, Xero, and Glasnonck.</Description>
         <Website>https://github.com/kotor-speedruns/Autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
