### PR TITLE
Added Romancing Saga 2 RotS and FFXVI

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,26 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Romancing Saga 2 Revenge of the Seven</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Denhonator/Load-Removers-and-Mods/refs/heads/main/Romancing%20SaGa%202%20RotS/RS2RotS.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Removal on PC by Denhonator</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Final Fantasy XVI</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Denhonator/Load-Removers-and-Mods/refs/heads/main/FF16/FF16.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Removal on PC by Denhonator</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Amanda the Adventurer 2</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Load removers for Romancing Saga 2 Revenge of the Seven and Final Fantasy XVI on PC

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
