### PR TITLE
Add LEGO Horizon Adventures and update locations for other Horizon games

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -22364,7 +22364,7 @@
         <Type>Script</Type>
         <Description>Load Remover for Horizon Forbidden West by ISO2768mK and DorianSnowball.</Description>
     </AutoSplitter>
-  <AutoSplitter>
+    <AutoSplitter>
         <Games>
             <Game>LEGO Horizon Adventures</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -22339,17 +22339,17 @@
             <Game>Horizon Zero Dawn</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/HorizonSpeedrun/horizon-load-remover/master/autosplitter/hzd-autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/HorizonSpeedrun/HorizonAutosplitters/main/HZD/hzd-autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Remover for Horizon Zero Dawn by ISO2768mK and DorianSnowball. Memory location found by Canine.</Description>
+        <Description>Load Remover and Autosplitter for Horizon Zero Dawn by ISO2768mK, Canine and DorianSnowball.</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Horizon Zero Dawn Remastered</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/HorizonSpeedrun/horizon-load-remover/master/autosplitter/hzdr-autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/HorizonSpeedrun/HorizonAutosplitters/main/HZD/hzdr-autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Load Remover for Horizon Zero Dawn Remastered by ISO2768mK and DorianSnowball.</Description>
@@ -22359,10 +22359,20 @@
             <Game>Horizon Forbidden West</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/HorizonSpeedrun/horizon-load-remover/master/autosplitter/hfw-autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/HorizonSpeedrun/HorizonAutosplitters/main/HFW/hfw-autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Load Remover for Horizon Forbidden West by ISO2768mK and DorianSnowball.</Description>
+    </AutoSplitter>
+  <AutoSplitter>
+        <Games>
+            <Game>LEGO Horizon Adventures</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/HorizonSpeedrun/HorizonAutosplitters/main/LHA/lha-autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Remover and Autosplitter for LEGO Horizon Adventures by Driver.</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
We've changed the repository structure, so this is the update for the new location.

Also adds the autosplitter for the new LEGO Horizon game.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
