### PR TITLE
Added Need for Speed: Hot Pursuit 2

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23944,4 +23944,14 @@
         <Type>Script</Type>
         <Description>Autosplitter and load remover</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Need for Speed: Hot Pursuit 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/C0rr4do/Autosplitters/refs/heads/main/Need%20for%20Speed%20Hot%20Pursuit%202/Need_for_Speed_Hot_Pursuit_2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Automatic Timer Start, Automatic Splits and Load Time Removal by C0rr4do</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
This ASL splits every time the player finishes an event that is on the Hot Pursuit event tree or the Championship event tree.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
