### PR TITLE
add Portal: Divinity under SAR

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6144,6 +6144,7 @@
             <Game>Portal: Unity Reboot</Game>
             <Game>Portal: After Hours</Game>
             <Game>INFRA</Game>
+            <Game>Portal: Divinity</Game>
         </Games>
         <URLs>
             <URL>https://github.com/p2sr/sar-auto-splitter/releases/download/latest/sar_auto_splitter.wasm</URL>


### PR DESCRIPTION
This adds another game under the Portal 2 and Mods autosplitter set using SourceAutoRecord. Same autosplitter, new game.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
