### PR TITLE
Change Marble It Up! & Ultra splitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19261,26 +19261,15 @@
     <AutoSplitter>
         <Games>
             <Game>Marble It Up!</Game>
-        </Games>
-        <URLs>
-            <URL>https://github.com/TalentedPlatinum/AutoSplitters/raw/main/MarbleItUp.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/raw/main/lib/UnityASL.bin</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Starts the timer automatically on Learning To Roll. Splits available in the settings. (by TalentedPlatinum, ero)</Description>
-        <Website>https://github.com/TalentedPlatinum/AutoSplitters/blob/main/README.md</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Marble It Up! Ultra</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/thearst3rd/autosplitters/main/LiveSplit.MarbleItUpUltra.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/raw/main/Components/UnityASL.bin</URL>
+            <URL>https://github.com/TalentedPlatinum/AutoSplitters/raw/main/MarbleItUp+Ultra.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Supports auto start, and splits on finishing and treasure box collection. (by thearst3rd, TalentedPlatinum, ero)</Description>
-        <Website>https://github.com/TalentedPlatinum/AutoSplitters/blob/main/README.md</Website>
+        <Description>Start and split settings available. (by ero, TalentedPlatinum, thearst3rd)</Description>
+        <Website>https://github.com/TalentedPlatinum/AutoSplitters</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
The autosplitters for Marble It Up! and Marble It Up! Ultra have been merged.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
