### PR TITLE
Fixed Disney Infinity: Inside Out

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23673,7 +23673,7 @@
             <Game>Disney Infinity: Inside Out</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/izzyhope58/ASL-Scripts/refs/heads/main/InsideOut.asl</URL>
+            <URL>https://raw.githubusercontent.com/izzyhope58/ASL-Scripts/refs/heads/main/Di_InsideOut.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitter and Loadremover. Created by IzzyHope58 with help from AndetSR</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23670,7 +23670,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Diseny Infinity: Inside Out</Game>
+            <Game>Disney Infinity: Inside Out</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/izzyhope58/ASL-Scripts/refs/heads/main/InsideOut.asl</URL>


### PR DESCRIPTION
Fixed Misspelling of Disney, and changed name of ASL so it dosn't conflict with others.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X ] The Auto Splitter has an open source license that allows anyone to fork and host it.
