### PR TITLE
Add Sugary Spire: Exhibition Night Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -24155,4 +24155,14 @@
         <Type>Script</Type>
         <Description>Auto Splitting and Load Removal available. Compare to IGT. (By TheDementedSalad)</Description>
     </AutoSplitter>
+        <AutoSplitter>
+        <Games>
+            <Game>Sugary Spire: Exhibition Night</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/avievie/ASL-Dump/refs/heads/main/SugarySpireExhibitionNight.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and Game Time sync for Sugary Spire</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
