### PR TITLE
Add asl-help into Sacre Bleu auto splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -24386,6 +24386,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/badBlackShark/ASL-Scripts/refs/heads/master/LiveSplit.SacreBleu.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/8adba2e5692cb94dd630a7bf5c0f772b58c1b938/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Automatic splitting, load removing, and combat time adjustments available (by badBlackShark)</Description>


### PR DESCRIPTION
The auto splitter was updated to use asl-help by ero, so the resource is now needed for everyone.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
