### PR TITLE
Add Project Wingman Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5896,6 +5896,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Project Wingman</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Hilimii/ProjectWingman_Autosplitter/refs/heads/main/PW_Autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter for Project Wingman Campaign and ILs. (By NitrogenCynic and Hilimii)</Description>
+        <Website>https://github.com/Hilimii/ProjectWingman_Autosplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Call of Duty 4: Modern Warfare</Game>
             <Game>Call of Duty 4: Speedrun Mod</Game>
         </Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

---

Adds an autosplitter for the game Project Wingman, supporting Campaign and Individual Level runs.