### PR TITLE
Added asl-help url for Hell of an Office

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -24598,6 +24598,7 @@
         </Games>
         <URLs>
             <URL>https://gist.githubusercontent.com/wRadion/b44f84cdd0233eb5e2e6ef024aa1b6e4/raw/hell-of-an-office_autosplitter.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitter and Load Remover available (by wRadion)</Description>


### PR DESCRIPTION
Not an autosplitter, just forgot to add the asl-help reference (because it was added afterwards).  

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
