### PR TITLE
Change Wilds name to Rise, and adding actual Wilds splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -24790,7 +24790,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Monster Hunter Wilds</Game>
+            <Game>Monster Hunter Rise</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TheDementedSalad/Monster-Hunter-Rise-Autosplitter/refs/heads/main/Monster%20Hunter%20Rise.asl</URL>
@@ -24799,5 +24799,17 @@
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting vailable. (By TheDementedSalad)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Monster Hunter Wilds</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TheDementedSalad/Monster-Hunter-Wilds-Autosplitter/refs/heads/main/Monster%20Hunter%20Wilds.asl</URL>
+            <URL>https://raw.githubusercontent.com/TheDementedSalad/Monster-Hunter-Wilds-Autosplitter/refs/heads/main/MHWilds.Settings.xml</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting  and Load Removal available. (By TheDementedSalad)</Description>
     </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.
