### PR TITLE
Update LiveSplit.AutoSplitters.xml to add the autosplitter for Final Fanatsy Adventure (GB)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -24866,4 +24866,16 @@
         <Type>Script</Type>
         <Description>Autosplitting  and Load Removal available. (By TheDementedSalad)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Final Fantasy Adventure</Game>
+            <Game>FFA</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Michy1212/Autosplitter-FFA/refs/heads/main/Autosplit%20FFA.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter for Final Fantasy Adventure/Seiken Densetsu: Final Fantasy Gaiden (By Michy1212 and verified by prieR57)</Description>
+        <Website>https://github.com/Michy1212/Autosplitter-FFA/blob/main/README.md</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Adding the autosplitter for Final Fantasy Adventure (GB)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
