### PR TITLE
Added Assassin's Creed Games Autosplitters/Loadremovers

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23131,7 +23131,7 @@
             <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACR.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter & Loadremover for Assassins Creed: Revelations (by TpRedNinja)</Description>
+        <Description>AutoSplitter and Loadremover for Assassins Creed: Revelations (by TpRedNinja)</Description>
         <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -23142,7 +23142,7 @@
             <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACU.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter & Loadremover for Assassins Creed: Unity (by AkiloGames)</Description>
+        <Description>AutoSplitter and Loadremover for Assassins Creed: Unity (by AkiloGames)</Description>
         <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -23153,7 +23153,7 @@
             <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACL.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter & Loadremover for Assassins Creed Liberation HD (by TpRedNinja)</Description>
+        <Description>AutoSplitter and Loadremover for Assassins Creed Liberation HD (by TpRedNinja)</Description>
         <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
     </AutoSplitter>
     <AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23077,7 +23077,98 @@
         </URLs>
         <Type>Script</Type>
         <Description>AutoSplitter and LoadRemover for Assassins Creed Syndicate (by TpRedNinja)</Description>
-        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/blob/main/ACS.asl</Website>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed IV: Black Flag</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/AC4BFSP.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter and LoadRemover for Assassins Creed 4 BlackFlag (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed: Brotherhood</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACB.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter & Loadremover for Assassins Creed: Brotherhood (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed: Revelations</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACR.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter & Loadremover for Assassins Creed: Revelations (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed: Unity</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACU.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter & Loadremover for Assassins Creed: Unity (by AkiloGames)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed Liberation HD </Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACL.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter & Loadremover for Assassins Creed Liberation HD (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed Chronicles: China</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACCChina.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter for Assassins Creed Chronicles: China (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed Chronicles: India</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACCIndia.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter for Assassins Creed Chronicles: India (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed Chronicles: Russia</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACCRussia.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter for Assassins Creed Chronicles: Russia (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -23215,7 +23306,7 @@
         </URLs>
         <Type>Script</Type>
         <Description>Auto Splitter for Assassins Creed III and Liberation Remastered (by TpRedNinja)</Description>
-        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/blob/main/AC3ACL.asl</Website>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23081,6 +23081,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Assassin's Creed III Remastered</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/main/AC3ACL.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitter and loadremover for Assassins Creed III and Liberation Remastered (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Assassin's Creed IV: Black Flag</Game>
         </Games>
         <URLs>
@@ -23294,17 +23305,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>Starts on Conductor, splits on level change, removes loads. (By WillTRM)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Assassin's Creed III Remastered</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/main/AC3ACL.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitter for Assassins Creed III and Liberation Remastered (by TpRedNinja)</Description>
-        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23092,6 +23092,28 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Assassin's Creed II</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/AC2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter and LoadRemover for Assassins Creed II (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Assassin's Creed Origins</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACO.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplitter and LoadRemover for Assassins Creed Origins (by TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Assassin's Creed: Brotherhood</Game>
         </Games>
         <URLs>
@@ -23144,30 +23166,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>AutoSplitter for Assassins Creed Chronicles: China (by TpRedNinja)</Description>
-        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Assassin's Creed Chronicles: India</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACCIndia.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>AutoSplitter for Assassins Creed Chronicles: India (by TpRedNinja)</Description>
-        <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Assassin's Creed Chronicles: Russia</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACCRussia.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>AutoSplitter for Assassins Creed Chronicles: Russia (by TpRedNinja)</Description>
         <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
     </AutoSplitter>
     <AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23131,7 +23131,7 @@
             <URL>https://raw.githubusercontent.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers/refs/heads/main/ACB.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>AutoSplitter & Loadremover for Assassins Creed: Brotherhood (by TpRedNinja)</Description>
+        <Description>AutoSplitter and Loadremover for Assassins Creed: Brotherhood (by TpRedNinja)</Description>
         <Website>https://github.com/TpRedNinja/Assassins-Creed-Autosplitters-and-loadremovers</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
Added autosplitters for
-Assassin's Creed IV: Black Flag
-Assassin's Creed Unity made by akilogames yes i got permission to add it to livesplit along with having it on github 
-Assassin's Creed: Brotherhood
-Assassin's Creed: Revelations
-Assassin's Creed Liberation HD
-Assassin's Creed Chronicles: China
-Assassin's Creed II
-Assassin's Creed Origins

Updated Websites for Syndicates autosplitter/loadremover and III Remastered autosplitter/loadremover

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
