### PR TITLE
Adding Splitter For Sniper Killer (Full Game)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25425,4 +25425,17 @@
         <Description>Auto-Splitter available (by JeFi). Please make sure to read the Website first.</Description>
         <Website>https://github.com/JeFi-314/JumpKing-AutoSplitterWS</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Sniper Killer (2024)</Game>
+            <Game>Sniper Killer (Full Game)</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TheDementedSalad/Sniper-Killer-Autosplitter/refs/heads/main/Sniper%20Killer.asl</URL>
+            <URL>https://raw.githubusercontent.com/TheDementedSalad/Sniper-Killer-Autosplitter/refs/heads/main/SniperKiller.Settings.xml</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Remover and level splits available (FOR FULL GAME). (By TheDementedSalad)</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
There's a splitter made for the Demo, but they're too different to be able to have them both in the same splitter imo.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
