### PR TITLE
Changing Diggity's Sniper Killer to Sniper Killer Demo

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2565,7 +2565,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Sniper Killer</Game>
+            <Game>Sniper Killer Demo</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Sniper%20Killer/sniperkillerdemo.asl</URL>
@@ -25428,7 +25428,8 @@
     <AutoSplitter>
         <Games>
             <Game>Sniper Killer (2024)</Game>
-            <Game>Sniper Killer (Full Game)</Game>
+            <Game>Sniper Killer Full Game</Game>
+            <Game>Sniper Killer</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TheDementedSalad/Sniper-Killer-Autosplitter/refs/heads/main/Sniper%20Killer.asl</URL>


### PR DESCRIPTION
The splitter Diggity made was for the demo, and with his permission I'm changing his splitters name to Sniper Killer Demo, and adding just Sniper Killer to mine since it's the full game.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
