### PR TITLE
Remove explicit mention of Steam for FF Pixel Remaster

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26112,7 +26112,7 @@
         </URLs>
         <Type>Script</Type>
         <ScriptType>AutoSplittingRuntime</ScriptType>
-        <Description>Configurable Autostarter and Autosplitter for the Pixel Remaster Steam version. (by knutwalker)</Description>
+        <Description>Configurable Autostarter and Autosplitter for the Pixel Remaster (by knutwalker)</Description>
         <Website>https://github.com/knutwalker/ff1pr-autosplitter#readme</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
It supports any version, not just Steam.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
