### PR TITLE
Add autosplitter for DSDA-Doom

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21421,6 +21421,24 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Ultimate Doom</Game>
+            <Game>Doom 2</Game>
+            <Game>Doom II</Game>
+            <Game>Final Doom</Game>
+            <Game>Plutonia Experiment</Game>
+            <Game>TNT: Evilution</Game>
+            <Game>DSDA Doom</Game>
+            <Game>DSDA-Doom</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Krankdud/dsda-doom-autosplitter/refs/heads/main/dsda-doom.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Demo timing, Auto Start/Split/Reset available (by Krankdud, Coincident, the_kovic)</Description>
+        <Website>https://github.com/Krankdud/dsda-doom-autosplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Holo Dungeon</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
This PR adds an ASL script for DSDA-Doom, the source port of choice for classic DOOM speedrunning (using demo files compatible with the original executables for DOS). Therefore, I also took aliases belonging to the classic DOOM IWADs.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
