### PR TITLE
Update FF8 URL

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -24801,7 +24801,7 @@
             <Game>Final Fantasy VIII</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/bodcap/ff8-auto-splitter/main/FF8Autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/ff8-speedruns/ff8-auto-splitter/main/FF8Autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto-splitter and CSR break pause (by naputimu, kaivel, jester1610, ElliotOrnitier)</Description>


### PR DESCRIPTION
No change to auto-splitter code, but changing the URL as the auto-splitter is now hosted on a more generic account.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
