### PR TITLE
Move Fantastic Fist Autosplitter to GitHub

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5,7 +5,7 @@
             <Game>Fantastic Fist</Game>
         </Games>
         <URLs>
-            <URL>https://git.sr.ht/~riolku/fantasticfist-asl/blob/main/fantasticfist.asl</URL>
+            <URL>https://github.com/Riolku/fantasticfist-asl/raw/main/fantasticfist.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/da804c285f35bd7ff8f532c94da99e69d9cb7eff/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>


### PR DESCRIPTION
Unfortunately the anti-bot measures of SourceHut make hosting there unrealistic.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
