### PR TITLE
Added Escape Simulator Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26479,4 +26479,15 @@
         <Type>Script</Type>
         <Description>Autosplitter (by mauer01)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Escape Simulator</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Undalevein/EscapeSimulatorAutosplitter/refs/heads/main/EscapeSimulator.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/blob/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/LiveSplit.ASLHelper.bin</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart, Autosplit, and load removal available. (By Undalevein)</Description>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26485,7 +26485,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Undalevein/EscapeSimulatorAutosplitter/refs/heads/main/EscapeSimulator.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/blob/main/lib/asl-help</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/da804c285f35bd7ff8f532c94da99e69d9cb7eff/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autostart, Autosplit, and load removal available. (By Undalevein)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26485,7 +26485,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Undalevein/EscapeSimulatorAutosplitter/refs/heads/main/EscapeSimulator.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/blob/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/LiveSplit.ASLHelper.bin</URL>
+            <URL>https://github.com/just-ero/asl-help/blob/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autostart, Autosplit, and load removal available. (By Undalevein)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26485,7 +26485,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Undalevein/EscapeSimulatorAutosplitter/refs/heads/main/EscapeSimulator.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/blob/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+            <URL>https://github.com/just-ero/asl-help/blob/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autostart, Autosplit, and load removal available. (By Undalevein)</Description>


### PR DESCRIPTION
Uses two files: the ASL file itself and a Unity ASL Helper file.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
