### PR TITLE
Change No One Lives Forever script path

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15127,7 +15127,7 @@
             <Game>The Operative: No One Lives Forever</Game>
         </Games>
         <URLs>
-            <URL>https://gist.githubusercontent.com/poacher2k/4655b01681705d67b277de8046397cce/raw/cdc63f54a365a9a93e611a0e11e260ac5e95dc8c/nolf1.asl</URL>
+            <URL>https://raw.githubusercontent.com/DVark09/livesplit-splitters/refs/heads/main/nolf.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Automatic starts, splits and resets, as well as load removal. (by poacher2k, all pointers by TheTedder)</Description>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.

The original author Poacher2k told me it's okay to replace the path to my repo since that has a newer version of the splitter and I can keep it maintained