### PR TITLE
Add load remover script to Dying Light CE

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7690,6 +7690,7 @@
     <AutoSplitter>
         <Games>
             <Game>Dying Light</Game>
+            <Game>Dying Light Category Extension</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/shadow2hel/Autosplitters/master/DyingLight/autostartnloadless.asl</URL>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
