### PR TITLE
change asl-help commit for invertigo

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25874,7 +25874,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/shlynz/Invertigo-LiveSplit-Stuff/refs/heads/main/invertigo.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+            <URL>https://raw.githubusercontent.com/just-ero/asl-help/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description> Autostart, autosplit and IGT support (by shlynz)</Description>


### PR DESCRIPTION
Since the game updated to use il2cpp the autosplitter stopped working, fixed by using this asl-help build along with the changes to the ASL in [this PR](https://github.com/shlynz/Invertigo-LiveSplit-Stuff/pull/2)
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
