### PR TITLE
Add asl-help url to unsighted

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5377,6 +5377,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/flyingwaff1e/AutoSplitter/refs/heads/main/unsighted.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting and load removal script made by callist03, Waff1e and WillTreaty</Description>


### PR DESCRIPTION
I forgot to add asl-help url after changing the repo. Sorry.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
