### PR TITLE
Add Crash Bandicoot: N. Sane Trilogy to LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26713,4 +26713,15 @@
         <Type>Script</Type>
         <Description>Auto Splitter is available. (By aut0mat1clol)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Crash Bandicoot: N. Sane Trilogy</Game>
+            <Game>Crash Bandicoot: N. Sane Trilogy Category Extensions</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/McCrodi/NST-Autosplitter/refs/heads/main/CrashNST.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Removing and Autosplitting for Crash Bandicoot: N. Sane Trilogy (PC Versions) (by McCrodi and Cumoshee)</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Add support to Crash Bandicoot: N. Sane Trilogy PC

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
