### PR TITLE
Add arcade Mortal Kombat II (MAME)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25619,6 +25619,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Mortal Kombat II</Game>
+            <Game>Mortal Kombat II Category Extensions</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/piratesephiroth/autosplitters/refs/heads/main/MK2-MAME.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter for the arcade version of Mortal Kombat II (MAME)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Mortal Kombat Trilogy</Game>
             <Game>Mortal Kombat Trilogy Category Extensions</Game>
         </Games>


### PR DESCRIPTION
Add arcade Mortal Kombat II (MAME)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
