### PR TITLE
Fixed 404'd Links for PEAK, Shinobi: Art of Vengeance, Shinobi 3 and Beyond Oasis

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -172,7 +172,7 @@
             <Game>Shinobi: Art of Vengeance</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/raw/refs/heads/main/Shinobi:%20Art%20of%20Vengeance/LiveSplit.ShinobiArtofVengeance.asl</URL>
+            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/refs/heads/main/Shinobi%3A%20Art%20of%20Vengeance/LiveSplit.ShinobiArtofVengeance.asl</URL>
             <URL>https://github.com/streetbackguy/Autosplitter-Projects/raw/refs/heads/main/Shinobi%20Component/unity-help-shinobi</URL>
         </URLs>
         <Type>Script</Type>
@@ -193,7 +193,7 @@
             <Game>Shinobi III: Return of the Ninja Master</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/raw/refs/heads/main/Shinobi%20III:%20Return%20of%20the%20Ninja%20Master/LiveSplit.Shinobi3ReturnoftheNinjaMaster.asl</URL>
+            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/refs/heads/main/Shinobi%20III%3A%20Return%20of%20the%20Ninja%20Master/LiveSplit.Shinobi3ReturnoftheNinjaMaster.asl</URL>
             <URL>https://github.com/Jujstme/emu-help-v3/raw/dc66ce576d8100c964bd37d170166e11135d91ca/lib/Livesplit/emu-help-v3</URL>
         </URLs>
         <Type>Script</Type>
@@ -330,7 +330,7 @@
             <Game>PEAK</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/raw/refs/heads/main/PEAK/LiveSplit.PEAK.asl</URL>
+            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/refs/heads/main/PEAK/LiveSplit.PEAK.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/da804c285f35bd7ff8f532c94da99e69d9cb7eff/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
@@ -363,7 +363,7 @@
             <Game>Beyond Oasis</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/raw/refs/heads/main/Beyond%20Oasis/LiveSplit.BeyondOasis.asl</URL>
+            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/refs/heads/main/Beyond%20Oasis/LiveSplit.BeyondOasis.asl</URL>
             <URL>https://github.com/Jujstme/emu-help/raw/master/lib/emu-help-v2</URL>
         </URLs>
         <Type>Script</Type>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.

Somehow when updating the XML with my updated links, these ones were broken so I have taken the liberty to fix them. Please could they be merged.