### PR TITLE
Update SWORN Autosplitter to Component

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25015,16 +25015,13 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Sworn Demo</Game>
             <Game>Sworn</Game>
         </Games>
         <URLs>
-            <URL>https://github.com/skiant/livesplit-asl/raw/refs/heads/main/sworn/sworn.asl</URL>
-            <URL>https://github.com/just-ero/asl-help/raw/a0f6c48f6813edb569a75152e6aba3dd4bc3ebe9/lib/asl-help</URL>
+            <URL>https://raw.githubusercontent.com/Nikoheartttv/LiveSplit.SWORN/main/Autosplitter/Release/Livesplit.SWORN.dll</URL>
         </URLs>
-        <Type>Script</Type>
-        <Description>IGT and Autosplitting available (by Skiant)</Description>
-        <Website>https://github.com/skiant/livesplit-asl/blob/main/sworn/README.md</Website>
+        <Type>Component</Type>
+        <Description>Autostart, Autosplit, Autoreset and IGT by Nikoheart</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

I have received permission from Skiant via Discord Direct Messages that I am allowed to replace their asl which only covered the demo with a component made in tandem with the developer and publishers for the 1.0 release of the game on the 23rd