### PR TITLE
Added uhara6 to Escape Simulator

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26906,7 +26906,7 @@
         <URLs>
             <URL>https://raw.githubusercontent.com/Undalevein/EscapeSimulatorAutosplitter/refs/heads/main/EscapeSimulator.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/da804c285f35bd7ff8f532c94da99e69d9cb7eff/lib/asl-help</URL>
-            <URL>https://github.com/ru-mii/uhara/raw/refs/heads/main/bin/uhara6<URL>
+            <URL>https://github.com/ru-mii/uhara/raw/refs/heads/main/bin/uhara6</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autostart, Autosplit, and load removal available. (By Undalevein)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26906,6 +26906,7 @@
         <URLs>
             <URL>https://raw.githubusercontent.com/Undalevein/EscapeSimulatorAutosplitter/refs/heads/main/EscapeSimulator.asl</URL>
             <URL>https://github.com/just-ero/asl-help/raw/da804c285f35bd7ff8f532c94da99e69d9cb7eff/lib/asl-help</URL>
+            <URL>https://github.com/ru-mii/uhara/raw/refs/heads/main/bin/uhara6<URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autostart, Autosplit, and load removal available. (By Undalevein)</Description>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
------------------------
Went back to the changing the script to remove all of the pointers and replace it with components through uhara6. I am well aware that there are new versions with uhara7+; however, when I worked on this couple months ago it was through uhara6. I tried using uhara7 but everything broke, so I have to use uhara6.