### PR TITLE
Add as many Portal (1) mods as possible.

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9878,7 +9878,6 @@
             <Game>Portal: Crumbs Of Truth</Game>
             <Game>Gamma Energy</Game>
             <Game>Portal Custom Maps</Game>
-            <Game>Blue Portals</Game>
             <Game>Portal: Still Alive</Game>	
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9870,6 +9870,16 @@
             <Game>Half-Life 2: Ghosting Mod</Game>
             <Game>Portal: The Flash Version MapPack</Game>
             <Game>Portal Reversed Map Order</Game>
+            <Game>Portal Bhop Mod</Game>
+            <Game>Aperture Narbacular</Game>
+            <Game>Portal Pro</Game>
+            <Game>Portal Unity</Game>
+            <Game>Portal Epic Edition</Game>
+            <Game>Portal: Crumbs Of Truth</Game>
+            <Game>Gamma Energy</Game>
+            <Game>Portal Custom Maps</Game>
+            <Game>Blue Portals</Game>
+            <Game>Portal: Still Alive</Game>	
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/thisis2838/SourceSplit/master/update/Components/LiveSplit.SourceSplit.dll</URL>


### PR DESCRIPTION
Added games listed here to SourceSplit.

- Aperture Narbacular
- Portal Bhop Mod
- Portal Custom Maps
- Portal Epic Edition
- Portal Pro
- Portal Unity
- Portal: Crumbs Of Truth
- Portal: Still Alive
- Gamma Energy            

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ YES ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ YES ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ YES ] The Auto Splitter has an open source license that allows anyone to fork and host it.

**(Not adding an AutoSplitter, adding games that the AuoSplitter supports to the AutoSplitter..)**

Have a nice day maintainer(s).