### PR TITLE
Add AutoSplitter for Powerwash Simulator

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -27267,4 +27267,17 @@
         <Type>Script</Type>
         <Description>Auto-splitting, start and load removal are available. (By Cadarev &amp; Psychonauter)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Powerwash Simulator</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Powewash-Simulator-autosplitter-and-load-remover/refs/heads/main/PWS.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+            <URL><URL>https://github.com/ru-mii/uhara/raw/refs/heads/main/bin/uhara9</URL></URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto-splitting, start and load removal are available. (By TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Powewash-Simulator-autosplitter-and-load-remover</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Added a new AutoSplitter for Powerwash Simulator with relevant URLs and description.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [ ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.
