### PR TITLE
Add I Wanna Be The Guy: Gaiden Auto Splitter (v1.0.0)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>I Wanna Be the Guy: Gaiden</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ACrowIAm/LiveSplit-Auto-Splitters/refs/heads/main/LiveSplit.IWBTGG.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>IWBTG:G (v1.2b) Auto Splitter (Made By ACrowIAm)</Description>
+        <Website>https://github.com/ACrowIAm</Website>  
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Kiki</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Game version is (v1.2b) but is listed as "v1.2" on Game Jolt: https://gamejolt.com/games/i-wanna-be-the-guy-gaiden/8598

Fully tested, works perfectly. Tested on 4 PC's and works identically on all of them.

Starts when you select a save and enter the "World Map" screen, splits on all three stages and resets when the game closes.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.
