### PR TITLE
Add I Wanna Be The Guy Auto Splitter (v1.0.0)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8,7 +8,7 @@
             <URL>https://raw.githubusercontent.com/ACrowIAm/LiveSplit-Auto-Splitters/refs/heads/main/LiveSplit.IWBTG.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>(FS) & (Slo Mo) Auto Splitter (Made By ACrowIAm)</Description>
+        <Description>(FS) and (Slo Mo) Auto Splitter (Made By ACrowIAm)</Description>
         <Website>https://github.com/ACrowIAm</Website>  
     </AutoSplitter>      
     <AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>I Wanna Be the Guy</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ACrowIAm/LiveSplit-Auto-Splitters/refs/heads/main/LiveSplit.IWBTG.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>(FS) & (Slo Mo) Auto Splitter (Made By ACrowIAm)</Description>
+        <Website>https://github.com/ACrowIAm</Website>  
+    </AutoSplitter>      
+    <AutoSplitter>
+        <Games>
             <Game>I Wanna Be the Guy: Gaiden</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Works on both game versions (Frame Skip) & (Slo Mo): https://gamejolt.com/games/i-wanna-be-the-guy/5

Fully tested, works perfectly. Tested on 3 PC's and works identically on all of them.

Starts when you select "New Game" from the save select screen, splits on all segments except the last(is togglable in the settings) and resets and starts upon selecting "New Game" again.

Has every route for both categories implemented into the settings.

Works on Windows 98 compatibility settings and as administrator.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.
