### PR TITLE
Update IWBTG:G Description

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -29,7 +29,7 @@
             <URL>https://raw.githubusercontent.com/ACrowIAm/LiveSplit-Auto-Splitters/refs/heads/main/LiveSplit.IWBTGG.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>IWBTG:G (v1.2b) Auto Splitter (Made By ACrowIAm)</Description>
+        <Description>(v1.2b) Auto Splitter (Made By ACrowIAm)</Description>
         <Website>https://github.com/ACrowIAm</Website>  
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
Removed "IWBTG:G" out of the description as it's not necessary.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.
