### PR TITLE
Updated autosplitter for Wolfenstein II: The New Colossus

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13350,10 +13350,11 @@
             <Game>Wolfenstein II: The New Colossus</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/itsjabo/LiveSplit/master/WolfensteinIITheNewColossus.asl</URL>
+            <URL>https://raw.githubusercontent.com/pjmaenh/wolf2-livesplit/master/wolf2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Removal is available. (By ItsJabo)</Description>
+        <Description>Autostart, autosplit and load removal are available. (Original by ItsJabo, updated and extended by pjmaenh)</Description>
+        <Website>https://github.com/pjmaenh/wolf2-livesplit</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Updated Wolfenstein II: The New Colossus AutoSplitter, with support for current patch and autosplitting.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [ ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

I have no contact info for the original author, but I created a  GitHub issue to ask for permission here:
https://github.com/itsjabo/Wolfenstein-II-The-New-Colossus/issues/1