### PR TITLE
Update description for Fatal Frame 2 Remake AutoSplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -79,7 +79,7 @@
             <URL>https://github.com/ru-mii/uhara/raw/refs/heads/main/bin/uhara10</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto-Start And Load-Removal For The 2026 Remake (By Arkhamfan69)</Description>
+        <Description>Load-Removal For The 2026 Remake by Arkhamfan69 and Streetbackguy</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
- I have added Patch 1.3.4.0 Support so added my name after Arkham's in the description.
- Autostart is temporarily removed as for some reason Autostart won't work, but once I look at it in the future, I may add it back on

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
