### PR TITLE
Added Key items and Petrified statues tracker for Archipelago runs

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9979,6 +9979,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/rythin-sr/ASL-Scripts/master/DarkSoulsII.asl</URL>
+            <URL>https://raw.githubusercontent.com/cobrce/DS2-Tracker-for-Archipelago/refs/heads/master/DS2_tracker.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting and Load Removal is available. (By Dread, rythin)</Description>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

(Fixed the XML issue found in the previous pull request)