### PR TITLE
Add Squeaky Squad game name alias

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -531,6 +531,7 @@
     <AutoSplitter>
         <Games>
             <Game>SQUEAKY SQUAD</Game>
+            <Game>Squeaky Squad</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Smokey34/SqueakySquad-Autosplitter/refs/heads/main/SqueakySquad.asl</URL>


### PR DESCRIPTION
Adds `Squeaky Squad` as an alias for the existing SQUEAKY SQUAD autosplitter entry.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
