### PR TITLE
add SECTOR ZERO and fix ARTIFICIAL game name

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5132,10 +5132,21 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>ARTIFICIAL Demo</Game>
+            <Game>ARTIFICIAL</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/JaioCG/autosplitters/master/ARTIFICIAL/artificial.asl</URL>
+            <URL>https://github.com/ero-qt/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter / In-Game Timer (by Jaio)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>SECTOR ZERO</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/JaioCG/autosplitters/refs/heads/master/SECTOR%20ZERO/sector-zero.asl</URL>
             <URL>https://github.com/ero-qt/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
