### PR TITLE
Update LiveSplit.AutoSplitters.xml - consolidate OpenGOAL Jak 1 games

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23470,6 +23470,8 @@
         <Games>
             <Game>OpenGOAL: Jak 1</Game>
             <Game>OpenGOAL: Jak 1 Category Extension</Game>
+            <Game>Gordon and Daxter</Game>
+            <Game>Jak and Daxter: JET-Board Legacy</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/open-goal/speedrunning/master/jak1/opengoal-jak1-autosplitter.asl</URL>
@@ -23517,28 +23519,6 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/my-opengoal-mods/OG-Jak-The-Chicken-Reborn/main/opengoal-jak1-autosplitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Starts, resets, splits. Use with "Speedrunner Mode" enabled!</Description>
-        <Website>https://jakmods.dev/</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Gordon and Daxter</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/open-goal/speedrunning/master/jak1/opengoal-jak1-autosplitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Starts, resets, splits. Use with "Speedrunner Mode" enabled!</Description>
-        <Website>https://jakmods.dev/</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Jak and Daxter: The JET-Board Legacy</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/open-goal/speedrunning/master/jak1/opengoal-jak1-autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Starts, resets, splits. Use with "Speedrunner Mode" enabled!</Description>


### PR DESCRIPTION
Merging a couple of mods into the same entry as the main game. Also fixing a typo in the name for JET-Board Legacy (no "The" on speedrun.com)

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
