### PR TITLE
Add Dreamworks Dragons: Wild Skies autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -29272,4 +29272,15 @@
         <Description>Auto start, configurable reset. Provides in-game time. Splits at every room, including boss chambers. (By Sam Pazur)</Description>
         <Website>https://github.com/sam0x2b/vivirun</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Dreamworks Dragons: Wild Skies</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/luis-rochoso/Wild-Skies-Autosplitter/refs/heads/main/WildSkies.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto splits and removes loading times in Wild Skies Any% (Made by Rochoso)</Description>
+        <Website>https://github.com/luis-rochoso/Wild-Skies-Autosplitter</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
