### PR TITLE
Removal of IWBTG:G entry from LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -350,17 +350,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>I Wanna Be the Guy: Gaiden</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/ACrowIAm/LiveSplit-Auto-Splitters/refs/heads/main/LiveSplit.IWBTGG.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>(v1.0) Auto Splitter (Made By ACrowIAm)</Description>
-        <Website>https://github.com/ACrowIAm</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Kiki</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
The script has bugs and contains unstable pointers that cannot trigger splits reliably.

Known bugs include:

The Stage 1 condition can get met when entering the stage. 
The Stage 1 condition gets met after a certain amount of time and splits prematurely. 
The Stage 1 condition gets met when the game closes and causes it to split then reset immediately after. 

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.


