### PR TITLE
Add Powerwash Simulator 2 AutoSplitter/load remover

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -28612,6 +28612,19 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Powerwash Simulator 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TpRedNinja/Powewash-Simulator-autosplitter-and-load-remover/refs/heads/main/PWS2.asl</URL>
+            <URL>https://github.com/ero-qt/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+            <URL>https://github.com/ru-mii/uhara/raw/refs/heads/main/bin/uhara10</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto-splitting, start and load removal are available. (By TpRedNinja)</Description>
+        <Website>https://github.com/TpRedNinja/Powewash-Simulator-autosplitter-and-load-remover</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>GRID Legends</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
