### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20484,6 +20484,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Enotria: The Last Song</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Fxyzzz/Enotria-The-Last-Song-Autosplitter/main/Enotria_The_Last_Song_Autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and Load Removed Time for PC. (by Fxyz)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>The Adventures of Elena Temple</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2948,7 +2948,6 @@
     <AutoSplitter>
         <Games>
             <Game>Enotria: The Last Song (Demo)</Game>
-            <Game>Enotria: The Last Song</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/refs/heads/main/Enotria%3A%20The%20Last%20Song/LiveSplit.EnotriaTheLastSongDemo.asl</URL>


### PR DESCRIPTION
I would like to add an autosplitter for Enotria: The Last Song.
The issue though is that the "spot" is already take by an old load time remover that is not supported anymore. Would it be possible to free the spot for only "Enotria: The Last Song" and not "Enotria: The Last Song (Demo)"?

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [Not really, but the already existing file is not an autosplitter, only a load time remover, and it is only compatible with the Demo. My file is a full autospliter for multiple versions of the release of the game] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
