### PR TITLE
Add Bloons TD6 AutoSplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9,7 +9,7 @@
         <URLs>
             <URL>https://raw.githubusercontent.com/Just-Ashley/BTD6-asl/refs/heads/main/BTD6.asl</URL>
         </URLs>
-        <Type>Script<Type>
+        <Type>Script</Type>
         <Description>Auto start, split, reset, and IGT by JustAshley for the Speedrun mod</Description>
     </AutoSplitter>
     <AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,18 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Bloons TD6</Game>
+            <Game>Bloons Tower Defense 6</Game>
+            <Game>BTD6</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Just-Ashley/BTD6-asl/refs/heads/main/BTD6.asl</URL>
+        </URLs>
+        <Type>Script<Type>
+        <Description>Auto start, split, reset, and IGT by JustAshley for the Speedrun mod</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Compress(space)</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Added support for Bloons TD6 in the AutoSplitters configuration.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
