### PR TITLE
Remove Phasmophobia Autosplitter because it no longer works from Update and stopped working on it

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21060,7 +21060,7 @@
             <URL>https://raw.githubusercontent.com/ru-mii/uhara/main/bin/uhara10</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Start/Split/Reset and Load Removal (By ItsFrosti)</Description>
+        <Description>Start/Split/Reset (By ItsFrosti) &amp; Load Removal (By InfaReQt)</Description>
         <Website>https://github.com/ItsFrostyYo/JTTSPAutosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
@@ -23281,16 +23281,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>Auto Splitting and IGT tracking (by NickRPGreen)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Journey to the Savage Planet</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/InfaReQt/JTTSP/main/LoadRemoverJTTSP.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Load Removal (by InfaReQt). Works for all current versions of the game.</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21053,6 +21053,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Journey to the Savage Planet</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ItsFrostyYo/JTTSPAutosplitter/refs/heads/main/asl/JTTSP.asl</URL>
+            <URL>https://raw.githubusercontent.com/ru-mii/uhara/main/bin/uhara10</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Start/Split/Reset and Load Removal (By ItsFrosti)</Description>
+        <Website>https://github.com/ItsFrostyYo/JTTSPAutosplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>The 7th Guest</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21034,6 +21034,7 @@
         <URLs>
             <URL>https://raw.githubusercontent.com/ItsFrostyYo/Subnautica2Autosplitter/main/asl/Subnautica2.asl</URL>
             <URL>https://raw.githubusercontent.com/ru-mii/uhara/main/bin/uhara10</URL>
+            <URL>https://raw.githubusercontent.com/ItsFrostyYo/uhara/main/bin/uharaSN2</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Start/Split/Reset and Cutscene Time Removal (By ItsFrosti &amp; Okia)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21123,6 +21123,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Object Impermanence</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ItsFrostyYo/ObjectImpermanenceASL/main/asl/ObjectImpermanence.asl</URL>
+            <URL>https://raw.githubusercontent.com/ItsFrostyYo/ObjectImpermanenceASL/main/Components/uhara10</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Start/Split/Reset and Load Removal (By ItsFrosti &amp; Jura)</Description>
+        <Website>https://github.com/ItsFrostyYo/ObjectImpermanenceASL</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>The 7th Guest</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -28331,17 +28331,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Phasmophobia</Game>
-            <Game>Phasmophobia Category Extensions</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/ItsFrostyYo/PhasmophobiaAutosplitter/main/Components/LiveSplit.PhasmophobiaAutosplitter.dll</URL>
-        </URLs>
-        <Type>Component</Type>
-        <Description>Start/Reset, Split and Load Time Removal for Phasmophobia (By ItsFrosti)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Huntsman</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -21060,7 +21060,7 @@
             <URL>https://raw.githubusercontent.com/ru-mii/uhara/main/bin/uhara10</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Start/Split/Reset (By ItsFrosti) &amp; Load Removal (By InfaReQt)</Description>
+        <Description>Start/Split/Reset and Load Removal (By ItsFrosti &amp; InfaReQt)</Description>
         <Website>https://github.com/ItsFrostyYo/JTTSPAutosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
