### PR TITLE
Add Pac-Man World Rally to autosplitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -28713,7 +28713,7 @@
         </URLs>
         <Type>Script</Type>
         <ScriptType>AutoSplittingRuntime</ScriptType>
-        <Description>Autosplitter is available. Load Remover available (also pauses timer during out-of-race menuing). Includes in-game timer.</Description>
+        <Description>Autosplitter, Load Remover, and In-Game Timer available.</Description>
         <Website>https://github.com/DThaiPome/PMWRAutoSplitter</Website>
     </AutoSplitter>
     <AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -28706,6 +28706,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Pac-Man World Rally</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/DThaiPome/PMWRAutoSplitter/releases/download/latest/pmwr_autosplitter.wasm</URL>
+        </URLs>
+        <Type>Script</Type>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Autosplitter is available. Load Remover available (also pauses timer during out-of-race menuing). Includes in-game timer.</Description>
+        <Website>https://github.com/DThaiPome/PMWRAutoSplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Gemini: Heroes Reborn</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
