### PR TITLE
Adding additional name for Coraline

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -447,6 +447,7 @@
     <AutoSplitter>
         <Games>
             <Game>Coraline</Game>
+            <Game>Coraline (PS2/Wii)</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/refs/heads/main/Coraline%20(PS2)/LiveSplit.CoralinePS2.asl</URL>


### PR DESCRIPTION
Adding additional name for Coraline, based on the leaderboard name for the game to support "easier" activation from within livesplit

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
