### PR TITLE
Add Infinitevania autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -29611,4 +29611,15 @@
         <Description>Hylics 2 Autosplitter and Load Remover</Description>
         <Website>https://github.com/MorganMustDie/Morgans-Autosplitters</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Infinitevania</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/sushi-de-linguica/infinite-splitter/main/Components/InfiniteSplitter.dll</URL>
+        </URLs>
+        <Type>Component</Type>
+        <Description>Start/Split/Reset and In-Game Time (By sushi-de-linguica)</Description>
+        <Website>https://github.com/sushi-de-linguica/infinite-splitter</Website>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
LiveSplit component providing Start/Split/Reset and In-Game Time for Infinitevania, read from the game's memory.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
