### PR TITLE
Added autosplitters for NFS MW Category Extensions and NFS ProStreet

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7071,6 +7071,26 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Need for Speed: Most Wanted (2005) Category Extensions</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/WilllTreaty/My-Autosplitters/main/Livesplit.NFSMW05.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and Load Remover made by TDOG20, Jigsaw, Balathruin and WillTreaty</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Need for Speed: ProStreet</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/xicecreaam/Additional-NFS-autosplitters/main/Livesplit.ProStreet.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and Load Remover made by SlivenKage</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>TimeSplitters: Future Perfect</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
For MW CE, the autosplitter/load remover will be the same, so same authors.
ProStreet autosplitter was missing.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- ✅ My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- ✅ I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- ✅ The Auto Splitter has an open source license that allows anyone to fork and host it.
