### PR TITLE
Update Total War: WARHAMMER II load remover source

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20005,10 +20005,10 @@
             <Game>Total War : Warhammer II</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/rythin-sr/ASL-Scripts/master/Warhammer2.asl</URL>
+            <URL>https://raw.githubusercontent.com/GresilGames/Warhammer2-Load-Remover/refs/heads/main/Warhammer2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Removal available. (by rythin)</Description>
+        <Description>Load Removal by rythin, updated for the current game version by Gresil</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20005,10 +20005,10 @@
             <Game>Total War : Warhammer II</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/GresilGames/Warhammer2-Load-Remover/refs/heads/main/Warhammer2.asl</URL>
+            <URL>https://raw.githubusercontent.com/GresilGames/Warhammer2-Load-Remover/main/Warhammer2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Removal by rythin, updated for the current game version by Gresil</Description>
+        <Description>Load Removal by rythin. Maintained by GresilGames.</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [ ] The Auto Splitter has an open source license that allows anyone to fork and host it.

This PR updates the Total War: WARHAMMER II autosplitter entry to point to a maintained repository.

The original autosplitter was created by rythin and the script continues to credit the original author. The original repository appears to no longer be maintained, so I updated the autosplitter for the current game version by rediscovering and validating the new static addresses.

The updated script preserves the original functionality while replacing obsolete addresses for:
- loading
- turn
- world_event

Because I could not find an open-source license in the original repository, I have left the license checkbox unchecked and preserved attribution to the original author.