### PR TITLE
Add autosplitter for Need for Speed: Carbon Category Extensions

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6766,6 +6766,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Need for Speed: Carbon Category Extensions</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/WilllTreaty/My-Autosplitters/main/Livesplit.NFSC.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and Loadless timer made by TDOG20, Mr. Mary and WillTreaty</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Inside | Out</Game>
             <Game>Inside|Out</Game>
             <Game>InsideOut</Game>


### PR DESCRIPTION
Like for Most Wanted, added a new autosplitter for Need for Speed: Carbon Category Extensions. It is the same file since categories use the same file.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- ✅ My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- ✅ I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- ✅ The Auto Splitter has an open source license that allows anyone to fork and host it.
