### PR TITLE
Add JSON URL for Supraland SIU autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -29648,6 +29648,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/dfego/autosplitters/refs/heads/main/Supraland%20SIU%20-%20Any%25%20Glitchless.asl</URL>
+            <URL>https://raw.githubusercontent.com/dfego/autosplitters/refs/heads/main/Supraland%20SIU%20-%20Any%25%20Glitchless.json</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitter for Supraland SIU, designed for Any% Glitchless</Description>


### PR DESCRIPTION
Recently updated splitter to be data-driven. This adds the JSON file to the downloaded URLs.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
