### PR TITLE
Add AutoSplitter for Oddworld Adventures

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20468,11 +20468,22 @@
             <Game>Oddworld Adventures 2</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/cyberianwilderness/Autosplitters-and-Split-Files/refs/heads/main/Oddworld-Adventures-II/OA2_Autosplitter.asll</URL>
+            <URL>https://raw.githubusercontent.com/cyberianwilderness/Autosplitters-and-Split-Files/refs/heads/main/Oddworld-Adventures-II/OA2_Autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>AutoSplit, AutoStart, AutoReset. Gambatte Emulator only. (by l1ndblum)</Description>
         <Website>https://www.speedrun.com/oad2</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Oddworld Adventures</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/cyberianwilderness/Autosplitters-and-Split-Files/refs/heads/main/Oddworld-Adventures/OA1-ASL.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>AutoSplit and AutoStart. Gambatte Emulator only. (by l1ndblum)</Description>
+        <Website>https://github.com/cyberianwilderness/Autosplitters-and-Split-Files/tree/main/Oddworld-Adventures</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -20469,6 +20469,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/cyberianwilderness/Autosplitters-and-Split-Files/refs/heads/main/Oddworld-Adventures-II/OA2_Autosplitter.asl</URL>
+            <URL>https://github.com/Jujstme/emu-help-v3/raw/dc66ce576d8100c964bd37d170166e11135d91ca/lib/Livesplit/emu-help-v3</URL>
         </URLs>
         <Type>Script</Type>
         <Description>AutoSplit, AutoStart, AutoReset. Gambatte Emulator only. (by l1ndblum)</Description>
@@ -20480,6 +20481,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/cyberianwilderness/Autosplitters-and-Split-Files/refs/heads/main/Oddworld-Adventures/OA1-ASL.asl</URL>
+            <URL>https://github.com/Jujstme/emu-help-v3/raw/dc66ce576d8100c964bd37d170166e11135d91ca/lib/Livesplit/emu-help-v3</URL>
         </URLs>
         <Type>Script</Type>
         <Description>AutoSplit and AutoStart. Gambatte Emulator only. (by l1ndblum)</Description>


### PR DESCRIPTION
Added new AutoSplitter for Oddworld Adventures
Fixed URL for Oddworld Adventures 2

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
