### PR TITLE
Add autosplitter for Need for Speed: Hot Pursuit Remastered

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7101,6 +7101,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Need for Speed: Hot Pursuit Remastered</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/xicecreaam/Additional-NFS-autosplitters/refs/heads/main/Livesplit.HotPursuitRemastered.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and Load Remover made by SlivenKage</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>TimeSplitters: Future Perfect</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
On behalf and by request of the creator.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- ✅ My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- ✅ I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- ✅ The Auto Splitter has an open source license that allows anyone to fork and host it.
