### PR TITLE
Add Path of Exile 2 (cross-platform WASM auto splitter)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,18 +2,6 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
-            <Game>Path of Exile 2</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/main/wasm/poe2_autosplitter.wasm</URL>
-        </URLs>
-        <Type>Script</Type>
-        <ScriptType>AutoSplittingRuntime</ScriptType>
-        <Description>Autosplitting is available. (By ransagy aka chaosblade; port of JakeDev/SavageOranges' component)</Description>
-        <Website>https://github.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/blob/main/wasm/README.md</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Ready or Not</Game>
         </Games>
         <URLs>
@@ -12544,6 +12532,11 @@
         <Type>Component</Type>
         <Description>An AutoSplitter for Path of Exile 2 (By JakeDev / SavageOranges)</Description>
         <Website>https://github.com/SavageOranges/PathOfExile2_AutoSplitterForLiveSplit/blob/main/README.md</Website>
+        <AutoSplittingRuntime>
+            <URL>https://raw.githubusercontent.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/main/wasm/poe2_autosplitter.wasm</URL>
+            <Description>Autosplitting is available. (Component by JakeDev/SavageOranges; WASM port by ransagy aka chaosblade)</Description>
+            <Website>https://github.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/blob/main/wasm/README.md</Website>
+        </AutoSplittingRuntime>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,18 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Path of Exile 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/main/wasm/poe2_autosplitter.wasm</URL>
+        </URLs>
+        <Type>Script</Type>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Autosplitting is available. (By ransagy aka chaosblade; port of JakeDev/SavageOranges' component)</Description>
+        <Website>https://github.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/blob/main/wasm/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Twisted Tower</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter. This adds a **separate** entry for Path of Exile 2; the existing component entry by JakeDev / SavageOranges is left untouched.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it. (MIT.)

### What does this PR do?

Adds a sandboxed Auto Splitting Runtime (WASM) auto splitter for **Path of Exile 2** — a cross-platform port of JakeDev/SavageOranges' LiveSplit component, so it runs in LiveSplit One on Linux/macOS/Windows without Windows-specific tooling.

Details:

- Module: https://raw.githubusercontent.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/main/wasm/poe2_autosplitter.wasm (prebuilt binary committed alongside Rust sources in [`wasm/`](https://github.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/tree/main/wasm))
- Same triggering model as the original component: reads the game's `Client.txt` log and splits on first entry into campaign areas; modes mirror the component's (Campaign 100%, Campaign Any%, Level), plus a Custom mode driven by the user's splits file
- Ships ready-made `.lss` split files mirroring those modes
- Handles mid-run game restarts and pause/resume edge cases
- Tested end-to-end on Linux with LiveSplit One, including a full Act 1 campaign run
- Setup guide: https://github.com/ransagy/PathOfExile2_AutoSplitterForLiveSplit/blob/main/wasm/README.md

Thanks to JakeDev/SavageOranges for the original component this port is based on.
