### PR TITLE
Update descriptions for God of war 1 and 2

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -27025,7 +27025,7 @@
             <URL>https://raw.githubusercontent.com/Dobridp/GoW2ASL/main/GoW2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>IGT for RPCS3 (by Dobrido).</Description>
+        <Description>RTA with Pausing for RPCS3 (by Dobrido).</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -29183,7 +29183,7 @@
             <URL>https://raw.githubusercontent.com/Dobridp/GoW1ASL/main/GoW1.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>IGT for RPCS3 (by Dobrido).</Description>
+        <Description>RTA with Pausing for RPCS3 (by Dobrido).</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Update descriptions for God of war 1 and 2 as IGT is no longer used in runs

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
