### PR TITLE
Add Timberborn autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25183,7 +25183,7 @@
             <URL>https://raw.githubusercontent.com/MHVandborg/timberborn_speedrun/master/autosplitter/timberborn.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto start/split for Timberborn - Wonder. Requires the "LiveSplit Autosplitter" mod from Thunderstore that can be found through the in-game mod browser. (By MHVandborg )</Description>
+        <Description>Auto start/split for Timberborn - Wonder. Requires "LiveSplit Autosplitter" mod (in-game mod browser). (By MHVandborg)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25177,6 +25177,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Timberborn</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/MHVandborg/timberborn_speedrun/master/autosplitter/timberborn.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start/split for Timberborn - Wonder. Requires the "LiveSplit Autosplitter" mod from Thunderstore that can be found through the in-game mod browser. (By MHVandborg )</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Timberman</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.


**What does this PR do?**

Adds an ASL autosplitter for Timberborn — Wonder category.

The script reads a JSON file written by a companion Timberborn mod - LiveSplit Autosplitter on [Thunderstore](https://thunderstore.io/c/timberborn/) that also can be found through the in-game mod browser [Steam](https://steamcommunity.com/sharedfiles/filedetails/?id=3791974455)). The mod is necessary because Timberborn has no file that reflects live game state during an active session — stats are only written to disk when the game autosaves.

Tested on Timberborn v1.0.