### PR TITLE
Add Hollow Knight cross-platform WASM autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13245,6 +13245,11 @@
         <Type>Component</Type>
         <Description>Configurable Load Remover / Auto Splitter. (By DevilSquirrel)</Description>
         <Website>https://github.com/ShootMe/LiveSplit.HollowKnight</Website>
+        <AutoSplittingRuntime>
+            <URL>https://github.com/AlexKnauth/hollowknight-autosplit-wasm/releases/latest/download/hollowknight_autosplit_wasm_stable.wasm</URL>
+            <Description>Configurable Load Remover / Auto Splitter / Auto Hit Counter. (By AlexKnauth)</Description>
+            <Website>https://github.com/AlexKnauth/hollowknight-autosplit-wasm</Website>
+        </AutoSplittingRuntime>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Following a discussion in #2878, this adds `hollowknight-autosplit-wasm` as a fallback alternative auto splitter for Hollow Knight, to the existing Component auto splitter entry. This has been tested to be equivalent to DevilSquirrel's Component auto splitter, and has been valid on Hollow Knight leaderboards since July 2024.