### PR TITLE
Add Ghostbusters: The Video Game (2009) Auto Splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6623,6 +6623,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Ghostbusters: The Video Game</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/sabrinaaa1701/gb-autosplitter/refs/heads/main/Ghostbusters2009.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitting and Load Removal for PC (2009) by KunoDemetries, modified by Sabrina1701</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Bloons Tower Defense 5</Game>
             <Game>BTD5</Game>
         </Games>


### PR DESCRIPTION
Add Ghostbusters (2009) AutoSplitter

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x ] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x ] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x ] The Auto Splitter has an open source license that allows anyone to fork and host it.
