### PR TITLE
Add auto splitter for Garden Trills

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -29943,6 +29943,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Garden Trills</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/cyberianwilderness/Autosplitters-and-Split-Files/refs/heads/main/Garden-Trills/Garden_Trills_ASL.asl</URL>
+            <URL>https://github.com/ru-mii/uhara/raw/refs/heads/main/bin/uhara10</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Start, Split, Reset and Load Removal (by L1ndblum)</Description>
+        <Website>https://www.speedrun.com/garden_trills</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Dream Chronicles 2: The Eternal Maze</Game>
             <Game>Dream Chronicles 2</Game>
         </Games>


### PR DESCRIPTION
Added new auto splitter for Garden Trills with relevant URLs and descriptions.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [\] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [\] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [\] The Auto Splitter has an open source license that allows anyone to fork and host it.
