### PR TITLE
Unify Ghostbusters: The Video Game & Remastered autosplitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -39,9 +39,10 @@
       <Game>Ghostbusters: The Video Game Remastered</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/sabrinaaa1701/gb-autosplitter/refs/heads/main/Ghostbusters2009.asl</URL>
+      <URL>https://raw.githubusercontent.com/sabrinaaa1701/gb-autosplitter/main/Ghostbusters2009.asl</URL>
     </URLs>
     <Description>Unified AutoSplitter &amp; Load Remover by Sabrina and KunoDemetries (2009, Steam, Epic)</Description>
+    <Type>Script</Type>
   </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -34,6 +34,16 @@
         <Description>Autosplitting and Load Removal by Nikoheart</Description>
     </AutoSplitter>
     <AutoSplitter>
+    <Games>
+      <Game>Ghostbusters: The Video Game</Game>
+      <Game>Ghostbusters: The Video Game Remastered</Game>
+    </Games>
+    <URLs>
+      <URL>https://raw.githubusercontent.com/sabrinaaa1701/gb-autosplitter/refs/heads/main/Ghostbusters2009.asl</URL>
+    </URLs>
+    <Description>Unified AutoSplitter &amp; Load Remover by Sabrina and KunoDemetries (2009, Steam, Epic)</Description>
+  </AutoSplitter>
+    <AutoSplitter>
         <Games>
             <Game>Myths Are 100&#x25; True</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -6635,26 +6635,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>GHOSTBUSTERS: THE VIDEO GAME REMASTERED</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/KunoDemetries/AutoSplitter/master/GhostbustersTheVideoGameRemastered.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitter/Load Remover (By KunoDemetries)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Ghostbusters: The Video Game</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/sabrinaaa1701/gb-autosplitter/refs/heads/main/Ghostbusters2009.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal for PC (2009) by KunoDemetries, modified by Sabrina1701</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Bloons Tower Defense 5</Game>
             <Game>BTD5</Game>
         </Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

Replaces the standalone 2009 and Remastered scripts with a single unified script. Supports 2009 (32-bit), Steam Remastered (64-bit), and Epic Games Remastered (64-bit) with automatic module size detection, load removal, route skip handling, and automated final cutscene splitting. Co-authored by Sabrina and KunoDemetries.
