### PR TITLE
add MGS4 + MGSPW

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19588,7 +19588,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Metal Gear Solid 4: Guns of the Patriots</Game>
+            <Game>Metal Gear Solid: Peace Walker (HD Edition)</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/hau5test/mgspwmc-autosplitter/refs/heads/master/mgspw.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19575,6 +19575,28 @@
         <Description>Game Time and Splits for PC and emulator. Split files available via Settings. Instructions at Website. (By bmn)</Description>
         <Website>https://github.com/bmn/livesplit_asl_mgs1/</Website>
     </AutoSplitter>
+     <AutoSplitter>
+        <Games>
+            <Game>Metal Gear Solid 4: Guns of the Patriots</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/hau5test/mgs4mc-autosplitter/refs/heads/main/mgs4.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Game Time and Splits for Master Collection PC version. Instructions at Website. (By Hau5test)</Description>
+        <Website>https://github.com/hau5test/mgs4mc-autosplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Metal Gear Solid 4: Guns of the Patriots</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/hau5test/mgspwmc-autosplitter/refs/heads/master/mgspw.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Game Time and Splits for Master Collection PC version. Instructions at Website. (By Hau5test)</Description>
+        <Website>https://github.com/hau5test/mgspwmc-autosplitter</Website>
+    </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Sensorium</Game>


### PR DESCRIPTION
added links to the Metal Gear Solid 4: Guns of the Patriots - PC autosplitter for the Master Collection Vol 2 version and Metal Gear Solid Peace Walker for the Master Collection Vol 2 PC version.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
