### PR TITLE
Removed emu-helper-v3 from Metal Gear: Ghost Babel

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -23705,10 +23705,9 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/NickRPGreen/Metal-Gear-Ghost-Babel-Autosplitter/main/Metal%20Gear%20Ghost%20Babel%20Autosplitter.asl</URL>
-            <URL>https://github.com/Jujstme/emu-help-v3/raw/dc66ce576d8100c964bd37d170166e11135d91ca/lib/Livesplit/emu-help-v3</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting and IGT tracking (by NickRPGreen)</Description>
+        <Description>Autosplitter and IGT tracking (by NickRPGreen)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
Metal Gear: Ghost Babel's autosplitter has been rewritten to be compatible with the new Master Collection Volume 2 version. As such, all emulators are now using the new memory location method, meaning emu-helper-v3 is no longer required.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
