### PR TITLE
Add Supraland autosplitter to LiveSplit configuration

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -29814,6 +29814,17 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Supraland</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/dfego/autosplitters/refs/heads/main/supraland.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter for Supraland, designed for Any% Glitchless</Description>
+        <Website>https://github.com/dfego/autosplitters</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Supraland Six Inches Under</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
Added the autosplitter for Supraland.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
