### PR TITLE
Removed my ASL for GoW 1 and 2 as they are no longer used

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -27106,16 +27106,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>God of War II</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Dobridp/GoW2ASL/main/GoW2.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>RTA with Pausing for RPCS3 (by Dobrido).</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Medal of Honor: Allied Assault</Game>
         </Games>
         <URLs>
@@ -29261,16 +29251,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>Autosplit, autostart and IGT support (by Stally and Zhrakula)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>God of War</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Dobridp/GoW1ASL/main/GoW1.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>RTA with Pausing for RPCS3 (by Dobrido).</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
