### PR TITLE
Modify Timberborn autosplitter to use WASM based splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25245,10 +25245,12 @@
             <Game>Timberborn</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/MHVandborg/timberborn_speedrun/master/autosplitter/timberborn.asl</URL>
+            <URL>https://github.com/Janzert/timberborn_autosplitter/releases/latest/download/timberborn_autosplitter.wasm</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto start/split for Timberborn - Wonder. Requires "LiveSplit Autosplitter" mod (in-game mod browser). (By MHVandborg)</Description>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Configurable auto start/split, with each split individually selectable. (By Janzert)</Description>
+        <Website>https://github.com/Janzert/timberborn_autosplitter</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
This replaces the previous ASL splitter that required a game mod installed to operate with a WASM based one that can run against the game unmodded.

@MHVandborg has given his permission to switch over to this splitter instead of his.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
