### PR TITLE
Update The Karters 2 autosplitter with new autosplitter url to remove old obsolete version

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25132,12 +25132,11 @@
             <Game>The Karters 2: Turbo Charged</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/PixelEdgeGames/TheKarters2_AutoSplitter/main/TheKarters2.asl</URL>
-            <URL>https://github.com/ero-qt/asl-help/raw/76750096863b03e7ebfdf748aef6d5d9464176a4/lib/asl-help</URL>
+            <URL>https://raw.githubusercontent.com/adelansari/TK2-ASL/main/TheKarters2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Basic AutoSplitter with Start/Pause timer during race. Ensure LiveSplit Compare Against is set to: Game Time</Description>
-        <Website>https://github.com/JakeRabinowitz/PogoChampAutosplitter</Website>
+        <Description>Autosplitter for The Karters 2 with automatic starts, finish line splits, and cumulative Cup IGT tracking. It is also a mid-race restart-resilient and has load pausing.</Description>
+        <Website>https://github.com/adelansari/TK2-ASL</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -25135,7 +25135,7 @@
             <URL>https://raw.githubusercontent.com/adelansari/TK2-ASL/main/TheKarters2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter for The Karters 2 with automatic starts, finish line splits, and cumulative Cup IGT tracking. It is also a mid-race restart-resilient and has load pausing.</Description>
+        <Description>Autosplitter for The Karters 2 with auto start, finish splits, Cup IGT, restart resilience, and load pausing.</Description>
         <Website>https://github.com/adelansari/TK2-ASL</Website>
     </AutoSplitter>
     <AutoSplitter>


### PR DESCRIPTION
The previous implementation relied on Mono-based class reflection via asl-help, which is incompatible with the current IL2CPP build of the game. This PR provides a fully working replacement (currently used in https://www.speedrun.com/The_Karters_2_Turbo_Charged) with updated pointer paths and IL2CPP support.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
