### PR TITLE
Add ASL-Help to MGS4 + MGSPW downloads

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -19581,6 +19581,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/hau5test/mgs4mc-autosplitter/refs/heads/main/mgs4.asl</URL>
+            <URL>https://github.com/ero-qt/asl-help/raw/9a17c5ec7108aba1fe1932358703f4e6adaa6b2c/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Game Time and Splits for Master Collection PC version. Instructions at Website. (By Hau5test)</Description>
@@ -19592,6 +19593,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/hau5test/mgspwmc-autosplitter/refs/heads/master/mgspw.asl</URL>
+            <URL>https://github.com/ero-qt/asl-help/raw/9a17c5ec7108aba1fe1932358703f4e6adaa6b2c/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Game Time and Splits for Master Collection PC version. Instructions at Website. (By Hau5test)</Description>


### PR DESCRIPTION
added missing links to ASL-Help which are required for both the splitters of Metal Gear Solid 4: Guns of The Patriots and Metal Gear Solid Peace Walker.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
