### PR TITLE
Add Onimusha: Way of the Sword autosplitter.

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -28700,6 +28700,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Onimusha: Way of the Sword</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/to-miz/autosplitters/refs/heads/main/OnimushaWotS.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart/Autosplitter/Load Removal available (by to-miz)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Madagascar: Escape 2 Africa</Game>
             <Game>Madagascar: Escape 2 Africa Category Extensions</Game>
         </Games>


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.
